### PR TITLE
Read NarmesteLederRelasjon from Kafka topic

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -59,6 +59,8 @@ spec:
         databases:
           - name: isnarmesteleder-db
         diskAutoresize: true
+  kafka:
+    pool: nav-dev
   env:
     - name: KTOR_ENV
       value: "production"
@@ -66,3 +68,5 @@ spec:
       value: "dev-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.dev-fss-pub.nais.io"
+    - name: TOGGLE_KAFKA_PROCESSING_ENABLED
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -59,6 +59,8 @@ spec:
         databases:
           - name: isnarmesteleder-db
         diskAutoresize: true
+  kafka:
+    pool: nav-prod
   env:
     - name: KTOR_ENV
       value: "production"
@@ -66,3 +68,5 @@ spec:
       value: "prod-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: SYFOTILGANGSKONTROLL_URL
       value: "https://syfo-tilgangskontroll.prod-fss-pub.nais.io"
+    - name: TOGGLE_KAFKA_PROCESSING_ENABLED
+      value: "false"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ object Versions {
     const val flyway = "7.15.0"
     const val hikari = "5.0.0"
     const val jackson = "2.11.4"
+    const val kafka = "2.7.0"
+    const val kafkaEmbedded = "2.5.0"
     const val ktor = "1.6.3"
     const val kluent = "1.68"
     const val logback = "1.2.3"
@@ -61,6 +63,10 @@ dependencies {
     implementation("com.zaxxer:HikariCP:${Versions.hikari}")
     implementation("org.postgresql:postgresql:${Versions.postgres}")
     testImplementation("com.opentable.components:otj-pg-embedded:${Versions.postgresEmbedded}")
+
+    // Kafka
+    implementation("org.apache.kafka:kafka_2.12:${Versions.kafka}")
+    testImplementation("no.nav:kafka-embedded-env:${Versions.kafkaEmbedded}")
 
     testImplementation("com.nimbusds:nimbus-jose-jwt:${Versions.nimbusJoseJwt}")
     testImplementation("io.ktor:ktor-server-test-host:${Versions.ktor}")

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -14,13 +14,31 @@ data class Environment(
     val isnarmestelederDbUsername: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_USERNAME"),
     val isnarmestelederDbPassword: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_PASSWORD"),
 
+    val kafka: ApplicationEnvironmentKafka = ApplicationEnvironmentKafka(
+        aivenBootstrapServers = getEnvVar("KAFKA_BROKERS"),
+        aivenCredstorePassword = getEnvVar("KAFKA_CREDSTORE_PASSWORD"),
+        aivenKeystoreLocation = getEnvVar("KAFKA_KEYSTORE_PATH"),
+        aivenSecurityProtocol = "SSL",
+        aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
+    ),
+
     val syfotilgangskontrollClientId: String = getEnvVar("SYFOTILGANGSKONTROLL_CLIENT_ID"),
     val syfotilgangskontrollUrl: String = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
+
+    val toggleKafkaProcessingEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_PROCESSING_ENABLED").toBoolean(),
 ) {
     fun jdbcUrl(): String {
         return "jdbc:postgresql://$isnarmestelederDbHost:$isnarmestelederDbPort/$isnarmestelederDbName"
     }
 }
+
+data class ApplicationEnvironmentKafka(
+    val aivenBootstrapServers: String,
+    val aivenCredstorePassword: String,
+    val aivenKeystoreLocation: String,
+    val aivenSecurityProtocol: String,
+    val aivenTruststoreLocation: String,
+)
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =
     System.getenv(varName) ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/NarmesteLederRelasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/NarmesteLederRelasjonService.kt
@@ -2,8 +2,8 @@ package no.nav.syfo.narmestelederrelasjon
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.narmestelederrelasjon.database.getNarmesteLederRelasjonList
 import no.nav.syfo.narmestelederrelasjon.database.domain.toNarmesteLederRelasjon
+import no.nav.syfo.narmestelederrelasjon.database.getNarmesteLederRelasjonList
 import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjon
 
 class NarmesteLederRelasjonService(

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NarmesteLederRelasjonQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NarmesteLederRelasjonQuery.kt
@@ -27,11 +27,13 @@ const val queryCreateNarmesteLederRelasjon =
         aktiv_fom,
         aktiv_tom,
         timestamp
-        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+        ) VALUES (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
+        RETURNING id
     """
 
 fun Connection.createNarmesteLederRelasjon(
-    commit: Boolean = true,
+    commit: Boolean,
     narmesteLederLeesah: NarmesteLederLeesah,
 ) {
     val narmesteLederRelasjonUuid = UUID.randomUUID()
@@ -54,7 +56,7 @@ fun Connection.createNarmesteLederRelasjon(
     }
 
     if (narmesteLederRelasjonIdList.size != 1) {
-        throw SQLException("Creating MoteStatusEndring failed, no rows affected.")
+        throw NoElementInsertedException("Creating NARMESTE_LEDER_RELASJON failed, no rows affected.")
     }
 
     if (commit) {

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NoElementInsertedException.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NoElementInsertedException.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.narmestelederrelasjon.database
+
+import java.sql.SQLException
+
+class NoElementInsertedException(message: String) : SQLException(message)

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/domain/PNarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/domain/PNarmesteLederRelasjon.kt
@@ -21,7 +21,7 @@ data class PNarmesteLederRelasjon(
     val aktivFom: LocalDate,
     val aktivTom: LocalDate?,
     val arbeidsgiverForskutterer: Boolean?,
-    val timestamp: OffsetDateTime?,
+    val timestamp: OffsetDateTime,
 )
 
 fun PNarmesteLederRelasjon.toNarmesteLederRelasjon() = NarmesteLederRelasjon(

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
@@ -22,7 +22,7 @@ data class NarmesteLederRelasjon(
     val aktivFom: LocalDate,
     val aktivTom: LocalDate?,
     val arbeidsgiverForskutterer: Boolean?,
-    val timestamp: OffsetDateTime?,
+    val timestamp: OffsetDateTime,
 )
 
 fun NarmesteLederRelasjon.toNarmesteLederRelasjonDTO() = NarmesteLederRelasjonDTO(
@@ -35,5 +35,5 @@ fun NarmesteLederRelasjon.toNarmesteLederRelasjonDTO() = NarmesteLederRelasjonDT
     arbeidsgiverForskutterer = this.arbeidsgiverForskutterer,
     aktivFom = this.aktivFom,
     aktivTom = this.aktivTom,
-    timestamp = this.timestamp?.toLocalDateTimeOslo(),
+    timestamp = this.timestamp.toLocalDateTimeOslo(),
 )

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaConfig.kt
@@ -1,0 +1,41 @@
+package no.nav.syfo.narmestelederrelasjon.kafka
+
+import no.nav.syfo.application.ApplicationEnvironmentKafka
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.*
+
+fun kafkaNarmesteLederRelasjonConsumerConfig(
+    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(applicationEnvironmentKafka))
+
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isnarmesteleder-v1"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+    }
+}
+
+private fun commonKafkaAivenConfig(
+    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+) = Properties().apply {
+    this[SaslConfigs.SASL_MECHANISM] = "PLAIN"
+    this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = applicationEnvironmentKafka.aivenBootstrapServers
+    this[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = applicationEnvironmentKafka.aivenSecurityProtocol
+    this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
+    this[SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG] = "jks"
+    this[SslConfigs.SSL_KEYSTORE_TYPE_CONFIG] = "PKCS12"
+    this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = applicationEnvironmentKafka.aivenTruststoreLocation
+    this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
+    this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = applicationEnvironmentKafka.aivenKeystoreLocation
+    this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
+    this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
+}

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaMetric.kt
@@ -1,0 +1,20 @@
+package no.nav.syfo.narmestelederrelasjon.kafka
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.metric.METRICS_NS
+import no.nav.syfo.metric.METRICS_REGISTRY
+
+const val KAFKA_CONSUMER_NARMESTELEDERRELASJON_BASE = "${METRICS_NS}_kafka_consumer_nlr"
+const val KAFKA_CONSUMER_NARMESTELEDERRELASJON_READ = "${KAFKA_CONSUMER_NARMESTELEDERRELASJON_BASE}_read"
+const val KAFKA_CONSUMER_NARMESTELEDERRELASJON_DUPLICATE = "${KAFKA_CONSUMER_NARMESTELEDERRELASJON_BASE}_duplicate"
+const val KAFKA_CONSUMER_NARMESTELEDERRELASJON_TOMBSTONE = "${KAFKA_CONSUMER_NARMESTELEDERRELASJON_BASE}_tombstone"
+
+val COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_READ: Counter = Counter.builder(KAFKA_CONSUMER_NARMESTELEDERRELASJON_READ)
+    .description("Counts the number of reads from topic - NarmesteLederRelasjon")
+    .register(METRICS_REGISTRY)
+val COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_DUPLICATE: Counter = Counter.builder(KAFKA_CONSUMER_NARMESTELEDERRELASJON_DUPLICATE)
+    .description("Counts the number of duplicates received from topic - NarmesteLederRelasjon")
+    .register(METRICS_REGISTRY)
+val COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_TOMBSTONE: Counter = Counter.builder(KAFKA_CONSUMER_NARMESTELEDERRELASJON_TOMBSTONE)
+    .description("Counts the number of tombstones received from topic - NarmesteLederRelasjon")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaModule.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.narmestelederrelasjon.kafka
+
+import kotlinx.coroutines.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.database.DatabaseInterface
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.narmestelederrelasjon.kafka")
+
+fun launchBackgroundTask(
+    applicationState: ApplicationState,
+    action: suspend CoroutineScope.() -> Unit
+): Job = GlobalScope.launch {
+    try {
+        action()
+    } catch (ex: Exception) {
+        log.error("Exception received while launching background task. Terminating application.", ex)
+    } finally {
+        applicationState.alive = false
+        applicationState.ready = false
+    }
+}
+
+fun launchKafkaTask(
+    applicationState: ApplicationState,
+    database: DatabaseInterface,
+    environment: Environment,
+) {
+    launchBackgroundTask(applicationState = applicationState) {
+        blockingApplicationLogicNarmesteLederRelasjon(
+            applicationState = applicationState,
+            database = database,
+            environment = environment,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaNarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaNarmesteLederRelasjon.kt
@@ -1,0 +1,88 @@
+package no.nav.syfo.narmestelederrelasjon.kafka
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.narmestelederrelasjon.database.NoElementInsertedException
+import no.nav.syfo.narmestelederrelasjon.database.createNarmesteLederRelasjon
+import no.nav.syfo.narmestelederrelasjon.kafka.domain.NarmesteLederLeesah
+import no.nav.syfo.util.*
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.narmestelederrelasjon.kafka")
+
+const val NARMESTE_LEDER_RELASJON_TOPIC = "teamsykmelding.syfo-narmesteleder-leesah"
+
+fun blockingApplicationLogicNarmesteLederRelasjon(
+    applicationState: ApplicationState,
+    database: DatabaseInterface,
+    environment: Environment,
+) {
+    log.info("Setting up kafka consumer NarmesteLederLeesah")
+
+    val consumerProperties = kafkaNarmesteLederRelasjonConsumerConfig(environment.kafka)
+    val kafkaConsumerNarmesteLederRelasjon = KafkaConsumer<String, String>(consumerProperties)
+
+    kafkaConsumerNarmesteLederRelasjon.subscribe(
+        listOf(NARMESTE_LEDER_RELASJON_TOPIC)
+    )
+    if (environment.toggleKafkaProcessingEnabled) {
+        while (applicationState.ready) {
+            pollAndProcessNarmesteLederRelasjon(
+                database = database,
+                kafkaConsumerNarmesteLederRelasjon = kafkaConsumerNarmesteLederRelasjon,
+            )
+        }
+    }
+}
+
+fun pollAndProcessNarmesteLederRelasjon(
+    database: DatabaseInterface,
+    kafkaConsumerNarmesteLederRelasjon: KafkaConsumer<String, String>,
+) {
+    val records = kafkaConsumerNarmesteLederRelasjon.poll(Duration.ofMillis(1000))
+    if (records.count() > 0) {
+        createAndStoreNarmesteLederRelasjonFromRecords(
+            consumerRecords = records,
+            database = database,
+        )
+        kafkaConsumerNarmesteLederRelasjon.commitSync()
+    }
+}
+
+fun createAndStoreNarmesteLederRelasjonFromRecords(
+    consumerRecords: ConsumerRecords<String, String>,
+    database: DatabaseInterface,
+) {
+    database.connection.use { connection ->
+        consumerRecords.forEach { consumerRecord ->
+            val callId = kafkaCallId()
+            if (consumerRecord.value() == null) {
+                log.error("Value of ConsumerRecord is null, most probably due to a tombstone. Contact the owner of the topic if an error is suspected. key=${consumerRecord.key()} from topic: ${consumerRecord.topic()}, partiion=${consumerRecord.partition()}, offset=${consumerRecord.offset()}")
+                COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_TOMBSTONE.increment()
+                return
+            }
+            val narmesteLederLeesah: NarmesteLederLeesah = configuredJacksonMapper()
+                .readValue(consumerRecord.value())
+
+            COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_READ.increment()
+            log.info("Received NarmesteLederLeesah, ready to process. id=${consumerRecord.key()}, timestamp=${consumerRecord.timestamp()}, callId=${callIdArgument(callId)}")
+
+            try {
+                connection.createNarmesteLederRelasjon(
+                    commit = false,
+                    narmesteLederLeesah = narmesteLederLeesah,
+                )
+            } catch (noElementInsertedException: NoElementInsertedException) {
+                log.warn("No NarmesteLederRelasjon was inserted into database, probably due to an attempt to insert a duplicate", noElementInsertedException)
+                COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_DUPLICATE.increment()
+            }
+        }
+        connection.commit()
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -4,6 +4,9 @@ import io.ktor.application.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.util.pipeline.*
 import net.logstash.logback.argument.StructuredArguments
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicInteger
 
 const val NAV_PERSONIDENT_HEADER = "nav-personident"
 
@@ -25,3 +28,7 @@ fun PipelineContext<out Unit, ApplicationCall>.getBearerHeader(): String? {
 fun PipelineContext<out Unit, ApplicationCall>.getPersonIdentHeader(): String? {
     return this.call.request.headers[NAV_PERSONIDENT_HEADER]
 }
+
+private val kafkaCounter = AtomicInteger(0)
+
+fun kafkaCallId(): String = "${LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd-MM-HHmm"))}-isnarmesteleder-kafka-${kafkaCounter.incrementAndGet()}"

--- a/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
@@ -1,12 +1,14 @@
 package testhelper
 
 import io.ktor.server.netty.*
+import no.nav.common.KafkaEnvironment
 import no.nav.syfo.application.ApplicationState
 import testhelper.mock.*
 
 class ExternalMockEnvironment {
     val applicationState: ApplicationState = testAppState()
     val database = TestDatabase()
+    val embeddedEnvironment: KafkaEnvironment = testKafka()
 
     val azureAdMock = AzureAdMock()
     val tilgangskontrollMock = VeilederTilgangskontrollMock()
@@ -18,6 +20,7 @@ class ExternalMockEnvironment {
 
     val environment = testEnvironment(
         azureOpenIdTokenEndpoint = azureAdMock.url,
+        kafkaBootstrapServers = embeddedEnvironment.brokersURL,
         syfotilgangskontrollUrl = tilgangskontrollMock.url,
     )
 
@@ -25,12 +28,14 @@ class ExternalMockEnvironment {
 }
 
 fun ExternalMockEnvironment.startExternalMocks() {
+    this.embeddedEnvironment.start()
     this.externalApplicationMockMap.start()
 }
 
 fun ExternalMockEnvironment.stopExternalMocks() {
     this.externalApplicationMockMap.stop()
     this.database.stop()
+    this.embeddedEnvironment.tearDown()
 }
 
 fun HashMap<String, NettyApplicationEngine>.start() {

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -1,17 +1,24 @@
 package testhelper
 
-import no.nav.syfo.application.ApplicationState
-import no.nav.syfo.application.Environment
+import no.nav.syfo.application.*
 import java.net.ServerSocket
 
 fun testEnvironment(
     azureOpenIdTokenEndpoint: String = "azureTokenEndpoint",
+    kafkaBootstrapServers: String,
     syfotilgangskontrollUrl: String = "tilgangskontroll",
 ) = Environment(
     azureAppClientId = "isdialogmote-client-id",
     azureAppClientSecret = "isdialogmote-secret",
     azureAppWellKnownUrl = "wellknown",
     azureOpenidConfigTokenEndpoint = azureOpenIdTokenEndpoint,
+    kafka = ApplicationEnvironmentKafka(
+        aivenBootstrapServers = kafkaBootstrapServers,
+        aivenCredstorePassword = "credstorepassord",
+        aivenKeystoreLocation = "keystore",
+        aivenSecurityProtocol = "SSL",
+        aivenTruststoreLocation = "truststore",
+    ),
     isnarmestelederDbHost = "localhost",
     isnarmestelederDbPort = "5432",
     isnarmestelederDbName = "isnarmesteleder_dev",
@@ -19,6 +26,7 @@ fun testEnvironment(
     isnarmestelederDbPassword = "password",
     syfotilgangskontrollClientId = "dev-fss.teamsykefravr.syfo-tilgangskontroll",
     syfotilgangskontrollUrl = syfotilgangskontrollUrl,
+    toggleKafkaProcessingEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/testhelper/TestKafka.kt
+++ b/src/test/kotlin/testhelper/TestKafka.kt
@@ -1,0 +1,16 @@
+package testhelper
+
+import no.nav.common.KafkaEnvironment
+import no.nav.syfo.narmestelederrelasjon.kafka.NARMESTE_LEDER_RELASJON_TOPIC
+
+fun testKafka(
+    autoStart: Boolean = false,
+    withSchemaRegistry: Boolean = false,
+    topicNames: List<String> = listOf(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+    )
+) = KafkaEnvironment(
+    autoStart = autoStart,
+    withSchemaRegistry = withSchemaRegistry,
+    topicNames = topicNames,
+)


### PR DESCRIPTION
Read NarmesteLederRelasjonLeesah from topic and store it in database.
Idempotence is ensured in the database with referanse_uuid set to UNIQUE to avoid storing duplicates based on the uuid narmesteLederId in the record. Each unique record is insert and noe rows are update to provide a complete history of NarmesteLederRelasjon.