### PR TITLE
Add NarmesteLederRelasjonStatus

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/NarmesteLederRelasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/NarmesteLederRelasjonService.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.narmestelederrelasjon
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.narmestelederrelasjon.database.domain.toNarmesteLederRelasjon
+import no.nav.syfo.narmestelederrelasjon.database.domain.toNarmesteLederRelasjonList
 import no.nav.syfo.narmestelederrelasjon.database.getNarmesteLederRelasjonList
 import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjon
 
@@ -12,10 +12,9 @@ class NarmesteLederRelasjonService(
     fun getRelasjonerForPersonIdent(
         personIdentNumber: PersonIdentNumber
     ): List<NarmesteLederRelasjon> {
-        return database.getNarmesteLederRelasjonList(
+        val pNarmesteLederRelasjonList = database.getNarmesteLederRelasjonList(
             personIdentNumber = personIdentNumber,
-        ).map {
-            it.toNarmesteLederRelasjon()
-        }
+        )
+        return pNarmesteLederRelasjonList.toNarmesteLederRelasjonList()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmesteLederRelasjonDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmesteLederRelasjonDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.narmestelederrelasjon.api
 
-import java.time.*
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class NarmesteLederRelasjonDTO(
     val uuid: String,
@@ -12,5 +13,6 @@ data class NarmesteLederRelasjonDTO(
     val aktivFom: LocalDate,
     val aktivTom: LocalDate?,
     val arbeidsgiverForskutterer: Boolean?,
-    val timestamp: LocalDateTime?,
+    val timestamp: LocalDateTime,
+    val status: String,
 )

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/domain/PNarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/domain/PNarmesteLederRelasjon.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.narmestelederrelasjon.database.domain
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjon
+import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjonStatus
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -24,7 +25,30 @@ data class PNarmesteLederRelasjon(
     val timestamp: OffsetDateTime,
 )
 
-fun PNarmesteLederRelasjon.toNarmesteLederRelasjon() = NarmesteLederRelasjon(
+fun List<PNarmesteLederRelasjon>.toNarmesteLederRelasjonList(): List<NarmesteLederRelasjon> {
+    val narmesteLederRelasjonVirksomhetsnummerMap = this.groupBy {
+        it.virksomhetsnummer
+    }
+    val returnList = mutableListOf<NarmesteLederRelasjon>()
+
+    narmesteLederRelasjonVirksomhetsnummerMap.entries.forEach { narmesteLederRelasjonVirksomhetsnummer ->
+        val pNarmesteLederRelasjonListByVirksomhetsnummer = narmesteLederRelasjonVirksomhetsnummer.value
+        returnList.addAll(
+            pNarmesteLederRelasjonListByVirksomhetsnummer.map { pNarmesteLederRelasjon ->
+                pNarmesteLederRelasjon.toNarmesteLederRelasjon(
+                    pNarmesteLederRelasjonList = pNarmesteLederRelasjonListByVirksomhetsnummer
+                )
+            }.sortedByDescending {
+                it.timestamp
+            }
+        )
+    }
+    return returnList
+}
+
+fun PNarmesteLederRelasjon.toNarmesteLederRelasjon(
+    pNarmesteLederRelasjonList: List<PNarmesteLederRelasjon>,
+) = NarmesteLederRelasjon(
     id = this.id,
     uuid = this.uuid,
     createdAt = this.createdAt,
@@ -39,4 +63,25 @@ fun PNarmesteLederRelasjon.toNarmesteLederRelasjon() = NarmesteLederRelasjon(
     aktivFom = this.aktivFom,
     aktivTom = this.aktivTom,
     timestamp = this.timestamp,
+    status = this.findStatus(pNarmesteLederRelasjonList = pNarmesteLederRelasjonList),
 )
+
+fun PNarmesteLederRelasjon.findStatus(
+    pNarmesteLederRelasjonList: List<PNarmesteLederRelasjon>,
+): NarmesteLederRelasjonStatus {
+    val isNarmesteLederRelasjonDeaktivert = this.aktivTom != null
+    return if (isNarmesteLederRelasjonDeaktivert) {
+        NarmesteLederRelasjonStatus.DEAKTIVERT
+    } else {
+        val narmesteLederRelasjonNewest = pNarmesteLederRelasjonList.maxByOrNull { narmesteLederRelasjon ->
+            narmesteLederRelasjon.timestamp
+        } ?: throw Exception("Cannot find type of NarmesteLederRelasjon: Empty narmesteLederRelasjonList was supplied")
+
+        val isThisAktiv = narmesteLederRelasjonNewest.aktivTom == null && this.referanseUuid === narmesteLederRelasjonNewest.referanseUuid
+        if (isThisAktiv) {
+            NarmesteLederRelasjonStatus.INNMELDT_AKTIV
+        } else {
+            NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
@@ -23,6 +23,7 @@ data class NarmesteLederRelasjon(
     val aktivTom: LocalDate?,
     val arbeidsgiverForskutterer: Boolean?,
     val timestamp: OffsetDateTime,
+    val status: NarmesteLederRelasjonStatus,
 )
 
 fun NarmesteLederRelasjon.toNarmesteLederRelasjonDTO() = NarmesteLederRelasjonDTO(
@@ -36,4 +37,11 @@ fun NarmesteLederRelasjon.toNarmesteLederRelasjonDTO() = NarmesteLederRelasjonDT
     aktivFom = this.aktivFom,
     aktivTom = this.aktivTom,
     timestamp = this.timestamp.toLocalDateTimeOslo(),
+    status = this.status.name,
 )
+
+enum class NarmesteLederRelasjonStatus {
+    INNMELDT_AKTIV,
+    INNMELDT_INAKTIV,
+    DEAKTIVERT,
+}

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
@@ -7,6 +7,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.narmestelederrelasjon.api.*
+import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjonStatus
 import no.nav.syfo.narmestelederrelasjon.kafka.NARMESTE_LEDER_RELASJON_TOPIC
 import no.nav.syfo.narmestelederrelasjon.kafka.pollAndProcessNarmesteLederRelasjon
 import no.nav.syfo.util.*
@@ -118,6 +119,7 @@ class NarmestelederApiSpek : Spek({
                             narmesteLederRelasjon.narmesteLederEpost shouldBeEqualTo narmesteLederLeesah.narmesteLederEpost
                             narmesteLederRelasjon.aktivFom shouldBeEqualTo narmesteLederLeesah.aktivFom
                             narmesteLederRelasjon.aktivTom shouldBeEqualTo narmesteLederLeesah.aktivTom
+                            narmesteLederRelasjon.status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_AKTIV.name
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/application/narmestelederrelasjon/domain/PNarmesteLederRelasjonSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmestelederrelasjon/domain/PNarmesteLederRelasjonSpek.kt
@@ -1,0 +1,218 @@
+package no.nav.syfo.application.narmestelederrelasjon.domain
+
+import no.nav.syfo.narmestelederrelasjon.database.domain.toNarmesteLederRelasjonList
+import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjonStatus
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER
+import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE
+import testhelper.UserConstants.VIRKSOMHETSNUMMER_ALTERNATIVE
+import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
+import testhelper.generator.generatePNarmesteLederRelasjon
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+class PNarmesteLederRelasjonSpek : Spek({
+    describe(PNarmesteLederRelasjonSpek::class.java.simpleName) {
+
+        val basePNarmesteLederRelasjon = generatePNarmesteLederRelasjon()
+
+        describe("Map list of PNarmesteLederRelasjon to list of NarmesteLederRelasjon: Multiple NarmesteLeder and multiple Virksomhetsnummer") {
+            it("with 2 Innmeldt, 1 Deaktivert and 1 Innmeldt should return list with 1 ${NarmesteLederRelasjonStatus.INNMELDT_AKTIV}") {
+                val firstInnmeldtVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    narmesteLederPersonIdentNumber = NARMESTELEDER_PERSONIDENTNUMBER,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = OffsetDateTime.now().minusDays(5),
+                )
+                val secondInnmeldtVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = firstInnmeldtVirksomhetsnummer1.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    narmesteLederPersonIdentNumber = NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = firstInnmeldtVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val deaktivertVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = secondInnmeldtVirksomhetsnummer1.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = LocalDate.now().minusDays(10),
+                    narmesteLederPersonIdentNumber = NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = secondInnmeldtVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val lastInnmeldtVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = deaktivertVirksomhetsnummer1.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    narmesteLederPersonIdentNumber = NARMESTELEDER_PERSONIDENTNUMBER,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = deaktivertVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val inputListVirksomhetsnummer1 = listOf(
+                    firstInnmeldtVirksomhetsnummer1,
+                    secondInnmeldtVirksomhetsnummer1,
+                    deaktivertVirksomhetsnummer1,
+                    lastInnmeldtVirksomhetsnummer1,
+                )
+                val firstInnmeldtVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = inputListVirksomhetsnummer1.size + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = OffsetDateTime.now().minusDays(5),
+                )
+                val secondInnmeldtVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = firstInnmeldtVirksomhetsnummer2.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = firstInnmeldtVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val deaktivertVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = secondInnmeldtVirksomhetsnummer2.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = LocalDate.now().minusDays(10),
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = secondInnmeldtVirksomhetsnummer2.timestamp.plusDays(1),
+                )
+                val lastInnmeldtVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = deaktivertVirksomhetsnummer2.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = deaktivertVirksomhetsnummer2.timestamp.plusDays(1),
+                )
+                val inputListVirksomhetsnummer2 = listOf(
+                    firstInnmeldtVirksomhetsnummer2,
+                    secondInnmeldtVirksomhetsnummer2,
+                    deaktivertVirksomhetsnummer2,
+                    lastInnmeldtVirksomhetsnummer2,
+                )
+                val outputList = inputListVirksomhetsnummer2.plus(inputListVirksomhetsnummer1).toNarmesteLederRelasjonList()
+
+                val outputListVirksomhetsnummer1 = outputList.filter {
+                    it.virksomhetsnummer.value == VIRKSOMHETSNUMMER_DEFAULT.value
+                }
+                outputListVirksomhetsnummer1.size shouldBeEqualTo inputListVirksomhetsnummer1.size
+
+                outputListVirksomhetsnummer1[0].id shouldBeEqualTo lastInnmeldtVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[0].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_AKTIV
+
+                outputListVirksomhetsnummer1[1].id shouldBeEqualTo deaktivertVirksomhetsnummer1.id
+                outputList[1].status shouldBeEqualTo NarmesteLederRelasjonStatus.DEAKTIVERT
+
+                outputListVirksomhetsnummer1[2].id shouldBeEqualTo secondInnmeldtVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[2].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                outputListVirksomhetsnummer1[3].id shouldBeEqualTo firstInnmeldtVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[3].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                val outputListVirksomhetsnummer2 = outputList.filter {
+                    it.virksomhetsnummer.value == VIRKSOMHETSNUMMER_ALTERNATIVE.value
+                }
+                outputListVirksomhetsnummer2.size shouldBeEqualTo inputListVirksomhetsnummer2.size
+
+                outputListVirksomhetsnummer2[0].id shouldBeEqualTo lastInnmeldtVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[0].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_AKTIV
+
+                outputListVirksomhetsnummer2[1].id shouldBeEqualTo deaktivertVirksomhetsnummer2.id
+                outputList[1].status shouldBeEqualTo NarmesteLederRelasjonStatus.DEAKTIVERT
+
+                outputListVirksomhetsnummer2[2].id shouldBeEqualTo secondInnmeldtVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[2].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                outputListVirksomhetsnummer2[3].id shouldBeEqualTo firstInnmeldtVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[3].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+            }
+
+            it("with 2 Innmeldt and 1 Deaktivert should return list without ${NarmesteLederRelasjonStatus.INNMELDT_AKTIV}") {
+                val firstInnmeldtVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = OffsetDateTime.now().minusDays(5),
+                )
+                val secondInnmeldtVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = firstInnmeldtVirksomhetsnummer1.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = firstInnmeldtVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val deaktivertVirksomhetsnummer1 = basePNarmesteLederRelasjon.copy(
+                    id = secondInnmeldtVirksomhetsnummer1.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = LocalDate.now().minusDays(10),
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+                    timestamp = secondInnmeldtVirksomhetsnummer1.timestamp.plusDays(1),
+                )
+                val inputListVirksomhetsnummer1 = listOf(
+                    firstInnmeldtVirksomhetsnummer1,
+                    secondInnmeldtVirksomhetsnummer1,
+                    deaktivertVirksomhetsnummer1,
+                )
+                val firstInnmeldtVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = inputListVirksomhetsnummer1.size + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = OffsetDateTime.now().minusDays(5),
+                )
+                val secondInnmeldtVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = firstInnmeldtVirksomhetsnummer2.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = null,
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = firstInnmeldtVirksomhetsnummer2.timestamp.plusDays(1),
+                )
+                val deaktivertVirksomhetsnummer2 = basePNarmesteLederRelasjon.copy(
+                    id = secondInnmeldtVirksomhetsnummer2.id + 1,
+                    referanseUuid = UUID.randomUUID(),
+                    aktivTom = LocalDate.now().minusDays(10),
+                    virksomhetsnummer = VIRKSOMHETSNUMMER_ALTERNATIVE,
+                    timestamp = secondInnmeldtVirksomhetsnummer2.timestamp.plusDays(1),
+                )
+                val inputListVirksomhetsnummer2 = listOf(
+                    firstInnmeldtVirksomhetsnummer2,
+                    secondInnmeldtVirksomhetsnummer2,
+                    deaktivertVirksomhetsnummer2,
+                )
+                val outputList = inputListVirksomhetsnummer2.plus(inputListVirksomhetsnummer1).toNarmesteLederRelasjonList()
+
+                val outputListVirksomhetsnummer1 = outputList.filter {
+                    it.virksomhetsnummer.value == VIRKSOMHETSNUMMER_DEFAULT.value
+                }
+                outputListVirksomhetsnummer1.size shouldBeEqualTo inputListVirksomhetsnummer1.size
+
+                outputListVirksomhetsnummer1[0].id shouldBeEqualTo deaktivertVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[0].status shouldBeEqualTo NarmesteLederRelasjonStatus.DEAKTIVERT
+
+                outputListVirksomhetsnummer1[1].id shouldBeEqualTo secondInnmeldtVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[1].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                outputListVirksomhetsnummer1[2].id shouldBeEqualTo firstInnmeldtVirksomhetsnummer1.id
+                outputListVirksomhetsnummer1[2].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                val outputListVirksomhetsnummer2 = outputList.filter {
+                    it.virksomhetsnummer.value == VIRKSOMHETSNUMMER_ALTERNATIVE.value
+                }
+                outputListVirksomhetsnummer2.size shouldBeEqualTo inputListVirksomhetsnummer2.size
+
+                outputListVirksomhetsnummer2[0].id shouldBeEqualTo deaktivertVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[0].status shouldBeEqualTo NarmesteLederRelasjonStatus.DEAKTIVERT
+
+                outputListVirksomhetsnummer2[1].id shouldBeEqualTo secondInnmeldtVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[1].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+
+                outputListVirksomhetsnummer2[2].id shouldBeEqualTo firstInnmeldtVirksomhetsnummer2.id
+                outputListVirksomhetsnummer2[2].status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_INAKTIV
+            }
+        }
+    }
+})

--- a/src/test/kotlin/testhelper/UserConstants.kt
+++ b/src/test/kotlin/testhelper/UserConstants.kt
@@ -8,8 +8,10 @@ object UserConstants {
     val ARBEIDSTAKER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "1"))
 
     val NARMESTELEDER_PERSONIDENTNUMBER = PersonIdentNumber("98765432101")
+    val NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE = PersonIdentNumber("98765432101")
 
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer("912345678")
+    val VIRKSOMHETSNUMMER_ALTERNATIVE = Virksomhetsnummer(VIRKSOMHETSNUMMER_DEFAULT.value.replace("1", "2"))
 
     const val VEILEDER_IDENT = "Z999999"
 }

--- a/src/test/kotlin/testhelper/generator/PNarmesteLederRelasjonGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/PNarmesteLederRelasjonGenerator.kt
@@ -1,0 +1,26 @@
+package testhelper.generator
+
+import no.nav.syfo.narmestelederrelasjon.database.domain.PNarmesteLederRelasjon
+import testhelper.UserConstants.ARBEIDSTAKER_FNR
+import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER
+import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+fun generatePNarmesteLederRelasjon() = PNarmesteLederRelasjon(
+    id = 1,
+    uuid = UUID.randomUUID(),
+    createdAt = OffsetDateTime.now(),
+    updatedAt = OffsetDateTime.now(),
+    referanseUuid = UUID.randomUUID(),
+    arbeidstakerPersonIdentNumber = ARBEIDSTAKER_FNR,
+    virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
+    narmesteLederPersonIdentNumber = NARMESTELEDER_PERSONIDENTNUMBER,
+    narmesteLederTelefonnummer = "99119911",
+    narmesteLederEpost = "test@test.com",
+    aktivFom = LocalDate.now().minusDays(10),
+    aktivTom = null,
+    arbeidsgiverForskutterer = null,
+    timestamp = OffsetDateTime.now().minusDays(5),
+)


### PR DESCRIPTION
Add NarmesteLederRelasjonStatus to make it easier for the consumer of the API to differantiate between types of NarmesteLederRelasjon. There can only be atmost 1 NarmesteLederRelasjon of type INNMELDT_AKTIV per pair of Arbeidstaker and Virksomhetsnummer.