### PR TITLE
Store empty Virksomhetsnavn if no Organisasjon is found in Ereg

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -19,12 +19,12 @@ class EregClient(
 ) {
     private val httpClient = httpClientDefault()
 
-    private val eregOrganisasjonUrl: String = "$baseUrl$EREG_PATH"
+    private val eregOrganisasjonUrl: String = "$baseUrl/$EREG_PATH"
 
-    suspend fun organisasjon(
+    suspend fun organisasjonVirksomhetsnavn(
         callId: String,
         virksomhetsnummer: Virksomhetsnummer,
-    ): EregOrganisasjonResponse? {
+    ): EregVirksomhetsnavn? {
         val systemToken = azureAdClient.getSystemToken(
             scopeClientId = isproxyClientId,
         )?.accessToken
@@ -38,9 +38,17 @@ class EregClient(
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_EREG_ORGANISASJON_SUCCESS.increment()
-            return response
+            return response.toEregVirksomhetsnavn()
         } catch (e: ClientRequestException) {
-            handleUnexpectedResponseException(e.response, e.message, callId)
+            if (e.isOrganisasjonNotFound(virksomhetsnummer)) {
+                log.warn("No Organisasjon was found in Ereg: returning empty Virksomhetsnavn, message=${e.message}, callId=$callId")
+                COUNT_CALL_EREG_ORGANISASJON_NOT_FOUND.increment()
+                return EregVirksomhetsnavn(
+                    virksomhetsnavn = "",
+                )
+            } else {
+                handleUnexpectedResponseException(e.response, e.message, callId)
+            }
         } catch (e: ServerResponseException) {
             handleUnexpectedResponseException(e.response, e.message, callId)
         }
@@ -59,6 +67,15 @@ class EregClient(
             StructuredArguments.keyValue("callId", callId),
         )
         COUNT_CALL_EREG_ORGANISASJON_FAIL.increment()
+    }
+
+    private fun ClientRequestException.isOrganisasjonNotFound(
+        virksomhetsnummer: Virksomhetsnummer,
+    ): Boolean {
+        val is404 = this.response.status == HttpStatusCode.NotFound
+        val messageNoVirksomhetsnavn = "Ingen organisasjon med organisasjonsnummer $virksomhetsnummer ble funnet"
+        val isMessageNoVirksomhetsnavn = this.message.contains(messageNoVirksomhetsnavn)
+        return is404 && isMessageNoVirksomhetsnavn
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClientMetric.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.metric.METRICS_REGISTRY
 const val CALL_EREG_ORGANISASJON_BASE = "${METRICS_NS}_call_ereg_organisasjon"
 const val CALL_EREG_ORGANISASJON_SUCCESS = "${CALL_EREG_ORGANISASJON_BASE}_success_count"
 const val CALL_EREG_ORGANISASJON_FAIL = "${CALL_EREG_ORGANISASJON_BASE}_fail_count"
+const val CALL_EREG_ORGANISASJON_NOT_FOUND = "${CALL_EREG_ORGANISASJON_BASE}_not_found_count"
 
 val COUNT_CALL_EREG_ORGANISASJON_SUCCESS: Counter = builder(CALL_EREG_ORGANISASJON_SUCCESS)
     .description("Counts the number of successful calls to Ereg - Organisasjon")
@@ -15,4 +16,8 @@ val COUNT_CALL_EREG_ORGANISASJON_SUCCESS: Counter = builder(CALL_EREG_ORGANISASJ
 
 val COUNT_CALL_EREG_ORGANISASJON_FAIL: Counter = builder(CALL_EREG_ORGANISASJON_FAIL)
     .description("Counts the number of failed calls to Ereg - Organisasjon")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_EREG_ORGANISASJON_NOT_FOUND: Counter = builder(CALL_EREG_ORGANISASJON_NOT_FOUND)
+    .description("Counts the number of calls failed to find Organisajon in Ereg")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregOrganisasjonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregOrganisasjonResponse.kt
@@ -9,11 +9,15 @@ data class EregOrganisasjonResponse(
     val navn: EregOrganisasjonNavn,
 )
 
-fun EregOrganisasjonResponse.virksomhetsnavn(): String =
+fun EregOrganisasjonResponse.toEregVirksomhetsnavn(): EregVirksomhetsnavn =
     this.navn.let { (navnelinje1, redigertnavn) ->
         if (redigertnavn.isNullOrBlank()) {
-            navnelinje1
+            EregVirksomhetsnavn(
+                virksomhetsnavn = navnelinje1
+            )
         } else {
-            redigertnavn
+            EregVirksomhetsnavn(
+                virksomhetsnavn = redigertnavn
+            )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregVirksomhetsnavn.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregVirksomhetsnavn.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.client.ereg
+
+data class EregVirksomhetsnavn(
+    val virksomhetsnavn: String,
+)

--- a/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/VirksomhetsnavnCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/virksomhetsnavn/VirksomhetsnavnCronjob.kt
@@ -1,10 +1,9 @@
 package no.nav.syfo.cronjob.virksomhetsnavn
 
 import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.client.ereg.EregClient
 import no.nav.syfo.cronjob.Cronjob
 import no.nav.syfo.cronjob.CronjobResult
-import no.nav.syfo.client.ereg.EregClient
-import no.nav.syfo.client.ereg.virksomhetsnavn
 import org.slf4j.LoggerFactory
 import java.util.*
 
@@ -25,15 +24,14 @@ class VirksomhetsnavnCronjob(
         val narmesteLederRelasjonList = virksomhetsnavnService.getNarmesteLederRelasjonWithoutVirksomhetsnavnList()
         narmesteLederRelasjonList.forEach { narmesteLederRelasjon ->
             try {
-                eregClient.organisasjon(
+                eregClient.organisasjonVirksomhetsnavn(
                     callId = UUID.randomUUID().toString(),
                     virksomhetsnummer = narmesteLederRelasjon.virksomhetsnummer,
                 )
-                    ?.virksomhetsnavn()
-                    ?.let { virksomhetsnavn ->
+                    ?.let { eregOrganisasjonVirksomhetsnavn ->
                         virksomhetsnavnService.updateVirksomhetsnavn(
                             narmesteLederRelasjonId = narmesteLederRelasjon.id,
-                            virksomhetsnavn = virksomhetsnavn,
+                            virksomhetsnavn = eregOrganisasjonVirksomhetsnavn.virksomhetsnavn,
                         )
                         virksomhetsnavnResult.updated++
                         COUNT_CRONJOB_VIRKSOMHETSNAVN_UPDATE.increment()

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
@@ -8,8 +8,8 @@ import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.ereg.EregClient
-import no.nav.syfo.client.ereg.virksomhetsnavn
 import no.nav.syfo.client.pdl.fullName
+import no.nav.syfo.client.ereg.toEregVirksomhetsnavn
 import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnService
 import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnCronjob
 import no.nav.syfo.narmestelederrelasjon.api.*
@@ -166,7 +166,7 @@ class NarmestelederApiSpek : Spek({
 
                             val narmesteLederRelasjon = narmestelederRelasjonList.first()
                             narmesteLederRelasjon.arbeidstakerPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.fnr
-                            narmesteLederRelasjon.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.isproxyMock.eregOrganisasjonResponse.virksomhetsnavn()
+                            narmesteLederRelasjon.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.isproxyMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
                             narmesteLederRelasjon.virksomhetsnummer shouldBeEqualTo narmesteLederLeesah.orgnummer
                             narmesteLederRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.narmesteLederFnr
                             narmesteLederRelasjon.narmesteLederTelefonnummer shouldBeEqualTo narmesteLederLeesah.narmesteLederTelefonnummer


### PR DESCRIPTION
If Ereg returns a 404 not found and returns a message saying that the Orginasjon requested does not exists, then a response with an empty Virksomhetsnavn is returned. This solution prevents the batchjob from repeatedly and infinitely failing to get a Virksomhetsnavn from Ereg.