### PR TITLE
Return list of NarmestelederRelasjon for all PersonIdent of a person

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.azuread.AzureAdToken
 import no.nav.syfo.client.httpClientDefault
+import no.nav.syfo.client.pdl.domain.*
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.util.*
 import org.slf4j.LoggerFactory
@@ -20,6 +21,96 @@ class PdlClient(
     private val redisStore: RedisStore,
 ) {
     private val httpClient = httpClientDefault()
+
+    suspend fun identList(
+        callId: String,
+        withHistory: Boolean,
+        personIdentNumber: PersonIdentNumber,
+    ): List<PersonIdentNumber>? {
+        val cacheKey = personIdentIdenterCacheKey(
+            personIdentNumber = personIdentNumber,
+        )
+        val cachedValue: PdlPersonidentIdenterCache? = redisStore.getObject(key = cacheKey)
+        if (cachedValue != null) {
+            COUNT_CALL_PDL_IDENTER_CACHE_HIT.increment()
+            return cachedValue.personIdentList.map { cachedPersonIdent ->
+                PersonIdentNumber(cachedPersonIdent)
+            }
+        } else {
+            COUNT_CALL_PDL_IDENTER_CACHE_MISS.increment()
+            return pdlIdenter(
+                callId = callId,
+                withHistory = withHistory,
+                personIdentNumber = personIdentNumber,
+            )?.hentIdenter?.let { identer ->
+                redisStore.setObject(
+                    key = cacheKey,
+                    value = PdlPersonidentIdenterCache(
+                        personIdentList = identer.identer.map { it.ident }
+                    ),
+                    expireSeconds = CACHE_PDL_PERSONIDENT_IDENTER_TIME_TO_LIVE_SECONDS
+                )
+                identer.toPersonIdentNumberList()
+            }
+        }
+    }
+
+    private suspend fun pdlIdenter(
+        callId: String,
+        withHistory: Boolean,
+        personIdentNumber: PersonIdentNumber,
+    ): PdlHentIdenter? {
+        val token = azureAdClient.getSystemToken(pdlClientId)
+            ?: throw RuntimeException("Failed to send PdlHentIdenterRequest to PDL: No token was found")
+
+        val query = getPdlQuery(
+            queryFilePath = "/pdl/hentIdenter.graphql",
+        )
+
+        val request = PdlHentIdenterRequest(
+            query = query,
+            variables = PdlHentIdenterRequestVariables(
+                ident = personIdentNumber.value,
+                historikk = withHistory,
+                grupper = listOf(
+                    IdentType.FOLKEREGISTERIDENT.name,
+                ),
+            ),
+        )
+
+        val response: HttpResponse = httpClient.post(pdlBaseUrl) {
+            body = request
+            header(HttpHeaders.Authorization, bearerHeader(token.accessToken))
+            header(HttpHeaders.ContentType, APPLICATION_JSON)
+            header(TEMA_HEADER, ALLE_TEMA_HEADERVERDI)
+            header(NAV_CALL_ID_HEADER, callId)
+            header(IDENTER_HEADER, IDENTER_HEADER)
+        }
+
+        when (response.status) {
+            HttpStatusCode.OK -> {
+                val pdlIdenterResponse = response.receive<PdlIdenterResponse>()
+                return if (!pdlIdenterResponse.errors.isNullOrEmpty()) {
+                    COUNT_CALL_PDL_PERSONBOLK_FAIL.increment()
+                    pdlIdenterResponse.errors.forEach {
+                        logger.error("Error while requesting IdentList from PersonDataLosningen: ${it.errorMessage()}")
+                    }
+                    null
+                } else {
+                    COUNT_CALL_PDL_IDENTER_SUCCESS.increment()
+                    pdlIdenterResponse.data
+                }
+            }
+            else -> {
+                COUNT_CALL_PDL_IDENTER_FAIL.increment()
+                logger.error("Request to get IdentList with url: $pdlBaseUrl failed with reponse code ${response.status.value}")
+                return null
+            }
+        }
+    }
+
+    private fun personIdentIdenterCacheKey(personIdentNumber: PersonIdentNumber) =
+        "$CACHE_PDL_PERSONIDENT_IDENTER_KEY_PREFIX${personIdentNumber.value}"
 
     suspend fun personIdentNumberNavnMap(
         callId: String,
@@ -155,6 +246,10 @@ class PdlClient(
     companion object {
         const val CACHE_PDL_PERSONIDENT_NAME_KEY_PREFIX = "pdl-personident-name-"
         const val CACHE_PDL_PERSONIDENT_NAME_TIME_TO_LIVE_SECONDS = 24 * 60 * 60L
+        const val CACHE_PDL_PERSONIDENT_IDENTER_KEY_PREFIX = "pdl-personident-identer-"
+        const val CACHE_PDL_PERSONIDENT_IDENTER_TIME_TO_LIVE_SECONDS = 12 * 60 * 60L
+
+        const val IDENTER_HEADER = "identer"
 
         private val logger = LoggerFactory.getLogger(PdlClient::class.java)
     }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
@@ -14,3 +14,24 @@ val COUNT_CALL_PDL_PERSONBOLK_SUCCESS: Counter = Counter.builder(CALL_PDL_PERSON
 val COUNT_CALL_PDL_PERSONBOLK_FAIL: Counter = Counter.builder(CALL_PDL_PERSONBOLK_FAIL)
     .description("Counts the number of failed calls to persondatalosning - personBolk")
     .register(METRICS_REGISTRY)
+
+const val CALL_PDL_IDENTER_BASE = "${METRICS_NS}_call_pdl_identer"
+const val CALL_PDL_IDENTER_SUCCESS = "${CALL_PDL_IDENTER_BASE}_success_count"
+const val CALL_PDL_IDENTER_FAIL = "${CALL_PDL_PERSONBOLK_BASE}_fail_count"
+
+val COUNT_CALL_PDL_IDENTER_SUCCESS: Counter = Counter.builder(CALL_PDL_IDENTER_SUCCESS)
+    .description("Counts the number of successful calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PDL_IDENTER_FAIL: Counter = Counter.builder(CALL_PDL_IDENTER_FAIL)
+    .description("Counts the number of failed calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)
+
+const val CALL_PDL_IDENTER_CACHE_HIT = "${CALL_PDL_IDENTER_BASE}_cache_hit_count"
+const val CALL_PDL_IDENTER_CACHE_MISS = "${CALL_PDL_IDENTER_BASE}_cache_miss_count"
+
+val COUNT_CALL_PDL_IDENTER_CACHE_HIT: Counter = Counter.builder(CALL_PDL_IDENTER_CACHE_HIT)
+    .description("Counts the number of cache hits for calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PDL_IDENTER_CACHE_MISS: Counter = Counter.builder(CALL_PDL_IDENTER_CACHE_MISS)
+    .description("Counts the number of cache misses for calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonidentIdenterCache.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonidentIdenterCache.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.client.pdl
+
+import java.io.Serializable
+
+data class PdlPersonidentIdenterCache(
+    val personIdentList: List<String>,
+) : Serializable

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlHentIdenterRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlHentIdenterRequest.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.client.pdl.domain
+
+data class PdlHentIdenterRequest(
+    val query: String,
+    val variables: PdlHentIdenterRequestVariables,
+)
+
+data class PdlHentIdenterRequestVariables(
+    val ident: String,
+    val historikk: Boolean,
+    val grupper: List<String>,
+)

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.client.pdl.domain
+
+import no.nav.syfo.client.pdl.PdlError
+import no.nav.syfo.domain.PersonIdentNumber
+
+data class PdlIdenterResponse(
+    val data: PdlHentIdenter?,
+    val errors: List<PdlError>?
+)
+
+data class PdlHentIdenter(
+    val hentIdenter: PdlIdenter?,
+)
+
+data class PdlIdenter(
+    val identer: List<PdlIdent>,
+)
+
+data class PdlIdent(
+    val ident: String,
+    val historisk: Boolean,
+    val gruppe: String,
+)
+
+enum class IdentType {
+    FOLKEREGISTERIDENT,
+}
+
+fun PdlIdenter.toPersonIdentNumberList(): List<PersonIdentNumber> =
+    this.identer.filter {
+        it.gruppe == IdentType.FOLKEREGISTERIDENT.name
+    }.let { pdlIdentList ->
+        pdlIdentList.map {
+            PersonIdentNumber(it.ident)
+        }
+    }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederApi.kt
@@ -38,9 +38,9 @@ fun Route.registrerNarmesteLederRelasjonApi(
                     token = token,
                 )
                 if (hasAccessToPerson) {
-                    val narmesteLederRelasjonDTOList = narmesteLederRelasjonService.getRelasjonerForPersonIdent(
+                    val narmesteLederRelasjonDTOList = narmesteLederRelasjonService.getNarmestelederRelasjonList(
                         callId = callId,
-                        personIdentNumber = personIdentNumber,
+                        arbeidstakerPersonIdentNumber = personIdentNumber,
                     ).map {
                         it.toNarmesteLederRelasjonDTO()
                     }

--- a/src/main/resources/pdl/hentIdenter.graphql
+++ b/src/main/resources/pdl/hentIdenter.graphql
@@ -1,0 +1,9 @@
+query($ident: ID!, $grupper: [IdentGruppe!], $historikk: Boolean = false){
+	hentIdenter(ident: $ident, grupper:$grupper, historikk:$historikk) {
+		identer {
+			ident,
+			historisk,
+			gruppe
+		}
+	}
+}

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
@@ -32,7 +32,9 @@ import testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import testhelper.UserConstants.VEILEDER_IDENT
 import testhelper.UserConstants.VIRKSOMHETSNUMMER_NO_VIRKSOMHETSNAVN
 import testhelper.generator.generateNarmesteLederLeesah
+import testhelper.mock.toHistoricalPersonIdentNumber
 import java.time.Duration
+import java.time.OffsetDateTime
 
 class NarmestelederApiSpek : Spek({
     val objectMapper: ObjectMapper = configuredJacksonMapper()
@@ -106,7 +108,9 @@ class NarmestelederApiSpek : Spek({
                         partition,
                     )
                     val narmesteLederLeesah = generateNarmesteLederLeesah(
+                        arbeidstakerPersonIdentNumber = ARBEIDSTAKER_FNR.toHistoricalPersonIdentNumber(),
                         status = null,
+                        timestamp = OffsetDateTime.now().minusDays(1),
                     )
                     val narmesteLederLeesahRecord = ConsumerRecord(
                         NARMESTE_LEDER_RELASJON_TOPIC,
@@ -147,7 +151,7 @@ class NarmestelederApiSpek : Spek({
                     )
                     every { mockConsumer.commitSync() } returns Unit
 
-                    it("should return list of NarmestelederRelasjon if request is successful") {
+                    it("should return list of NarmestelederRelasjon for all historical PersonIdent if request is successful") {
                         runBlocking {
                             pollAndProcessNarmesteLederRelasjon(
                                 database = database,
@@ -184,19 +188,19 @@ class NarmestelederApiSpek : Spek({
 
                             narmestelederRelasjonList.size shouldBeEqualTo 1
 
-                            val narmesteLederRelasjon = narmestelederRelasjonList.first()
-                            narmesteLederRelasjon.arbeidstakerPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.fnr
-                            narmesteLederRelasjon.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.isproxyMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
-                            narmesteLederRelasjon.virksomhetsnummer shouldBeEqualTo narmesteLederLeesah.orgnummer
-                            narmesteLederRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.narmesteLederFnr
-                            narmesteLederRelasjon.narmesteLederTelefonnummer shouldBeEqualTo narmesteLederLeesah.narmesteLederTelefonnummer
-                            narmesteLederRelasjon.narmesteLederEpost shouldBeEqualTo narmesteLederLeesah.narmesteLederEpost
-                            narmesteLederRelasjon.narmesteLederNavn shouldBeEqualTo externalMockEnvironment.pdlMock.respons.data.hentPersonBolk?.get(
+                            val narmesteLederRelasjonDeaktivert = narmestelederRelasjonList.first()
+                            narmesteLederRelasjonDeaktivert.arbeidstakerPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
+                            narmesteLederRelasjonDeaktivert.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.isproxyMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
+                            narmesteLederRelasjonDeaktivert.virksomhetsnummer shouldBeEqualTo narmesteLederLeesah.orgnummer
+                            narmesteLederRelasjonDeaktivert.narmesteLederPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.narmesteLederFnr
+                            narmesteLederRelasjonDeaktivert.narmesteLederTelefonnummer shouldBeEqualTo narmesteLederLeesah.narmesteLederTelefonnummer
+                            narmesteLederRelasjonDeaktivert.narmesteLederEpost shouldBeEqualTo narmesteLederLeesah.narmesteLederEpost
+                            narmesteLederRelasjonDeaktivert.narmesteLederNavn shouldBeEqualTo externalMockEnvironment.pdlMock.respons.data.hentPersonBolk?.get(
                                 0
                             )?.person?.fullName()
-                            narmesteLederRelasjon.aktivFom shouldBeEqualTo narmesteLederLeesah.aktivFom
-                            narmesteLederRelasjon.aktivTom shouldBeEqualTo narmesteLederLeesah.aktivTom
-                            narmesteLederRelasjon.status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_AKTIV.name
+                            narmesteLederRelasjonDeaktivert.aktivFom shouldBeEqualTo narmesteLederLeesah.aktivFom
+                            narmesteLederRelasjonDeaktivert.aktivTom shouldBeEqualTo narmesteLederLeesah.aktivTom
+                            narmesteLederRelasjonDeaktivert.status shouldBeEqualTo NarmesteLederRelasjonStatus.INNMELDT_AKTIV.name
                         }
                     }
                 }

--- a/src/test/kotlin/testhelper/generator/NarmesteLederLeesahGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/NarmesteLederLeesahGenerator.kt
@@ -7,7 +7,6 @@ import no.nav.syfo.narmestelederrelasjon.kafka.domain.NarmesteLederLeesah
 import testhelper.UserConstants
 import testhelper.UserConstants.ARBEIDSTAKER_FNR
 import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER
-import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -15,6 +14,7 @@ import java.util.*
 fun generateNarmesteLederLeesah(
     arbeidstakerPersonIdentNumber: PersonIdentNumber = ARBEIDSTAKER_FNR,
     status: String? = NY_LEDER,
+    timestamp: OffsetDateTime = OffsetDateTime.now().minusDays(5),
     virksomhetsnummer: Virksomhetsnummer = UserConstants.VIRKSOMHETSNUMMER_DEFAULT,
 ) = NarmesteLederLeesah(
     narmesteLederId = UUID.randomUUID(),
@@ -26,6 +26,6 @@ fun generateNarmesteLederLeesah(
     aktivFom = LocalDate.now().minusDays(10),
     aktivTom = null,
     arbeidsgiverForskutterer = null,
-    timestamp = OffsetDateTime.now().minusDays(5),
+    timestamp = timestamp,
     status = status,
 )


### PR DESCRIPTION
Over time, A person can have multiple PersonIdent due to changes in Folkeregisteret. To account for these change, the API now returns a list of NarmestelederRelasjon for a person, not only for a given PersonIdent of a person.  Changes in PersonIdent is abstracted away from the API consumer and the consumer gets a list of NarmestelederRelasjon for all historical PersonIdent by supplying a single PersonIdent.