### PR TITLE
Add option in system api for getting ansatte instead of ledere

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederApi.kt
@@ -40,7 +40,8 @@ fun Route.registrerNarmesteLederRelasjonApi(
             if (hasAccessToPerson) {
                 val narmesteLederRelasjonDTOList = narmesteLederRelasjonService.getNarmestelederRelasjonList(
                     callId = callId,
-                    arbeidstakerPersonIdentNumber = personIdentNumber,
+                    personIdentNumber = personIdentNumber,
+                    shouldGetAnsatte = false,
                 ).map {
                     it.toNarmesteLederRelasjonDTO()
                 }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederSystemApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederSystemApi.kt
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
 
 const val narmesteLederSystemApiV1Path = "/api/system/v1/narmestelederrelasjoner"
+const val ANSATTE_QUERYPARAM = "ansatte"
 
 fun Route.registrerNarmesteLederRelasjonSystemApi(
     apiConsumerAccessService: APIConsumerAccessService,
@@ -36,9 +37,12 @@ fun Route.registrerNarmesteLederRelasjonSystemApi(
             }
                 ?: throw IllegalArgumentException("No PersonIdent supplied to system api when getting narmestelederRelasjoner, callID=$callId")
 
+            val shouldGetAnsatte = this.call.request.queryParameters[ANSATTE_QUERYPARAM].toBoolean()
+
             val narmesteLederRelasjonDTOList = narmesteLederRelasjonService.getNarmestelederRelasjonList(
                 callId = callId,
-                arbeidstakerPersonIdentNumber = personIdentNumber,
+                personIdentNumber = personIdentNumber,
+                shouldGetAnsatte = shouldGetAnsatte,
             ).map {
                 it.toNarmesteLederRelasjonDTO()
             }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NarmesteLederRelasjonQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/database/NarmesteLederRelasjonQuery.kt
@@ -114,11 +114,21 @@ const val queryGetNarmesteLederRelasjonList =
     WHERE arbeidstaker_personident = ?;
     """
 
+const val queryGetAnsatteList =
+    """
+    SELECT *
+    FROM narmeste_leder_relasjon
+    WHERE narmeste_leder_personident = ?;
+    """
+
 fun DatabaseInterface.getNarmesteLederRelasjonList(
     personIdentNumber: PersonIdentNumber,
+    shouldGetAnsatte: Boolean,
 ): List<PNarmesteLederRelasjon> {
+    val query = if (shouldGetAnsatte) queryGetAnsatteList else queryGetNarmesteLederRelasjonList
+
     return this.connection.use { connection ->
-        connection.prepareStatement(queryGetNarmesteLederRelasjonList).use {
+        connection.prepareStatement(query).use {
             it.setString(1, personIdentNumber.value)
             it.executeQuery().toList {
                 toPNarmesteLederRelasjon()

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/domain/NarmesteLederRelasjon.kt
@@ -58,6 +58,18 @@ fun List<NarmesteLederRelasjon>.addNarmesteLederName(
     }
 }
 
+fun NarmesteLederRelasjon.newArbeidstakerPersonIdentNumber(newIdent: PersonIdentNumber): NarmesteLederRelasjon {
+    return this.copy(
+        arbeidstakerPersonIdentNumber = newIdent,
+    )
+}
+
+fun NarmesteLederRelasjon.newNarmesteLederPersonIdentNumber(newIdent: PersonIdentNumber): NarmesteLederRelasjon {
+    return this.copy(
+        narmesteLederPersonIdentNumber = newIdent,
+    )
+}
+
 enum class NarmesteLederRelasjonStatus {
     INNMELDT_AKTIV,
     DEAKTIVERT,

--- a/src/test/kotlin/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/testhelper/mock/PdlMock.kt
@@ -17,10 +17,10 @@ import testhelper.getRandomPort
 
 fun PersonIdentNumber.toHistoricalPersonIdentNumber(): PersonIdentNumber {
     val firstDigit = this.value[0].digitToInt()
-    val newDigit = firstDigit + 4
+    val lastDigitOfNewNumber = (firstDigit + 4) % 10
     val dNummer = this.value.replace(
         firstDigit.toString(),
-        newDigit.toString(),
+        lastDigitOfNewNumber.toString(),
     )
     return PersonIdentNumber(dNummer)
 }


### PR DESCRIPTION
Bruk query param for å velge ansatte.
For ansatte er det en endring i sql-spørringen, der man finner fnr for leder i stedet for innbygger.
Legg til en test for ansatte, som gjør omtrent det samme som den for ledere.
Endre PdlMock sin toHistoricalIdentNumber metode til å kun bruke ett siffer: I testdataene har lederen et fnr som begynner på 9, da får man en ugyldig PersonIdent når man legger til 4, men nå tar vi høyde for det.