### PR TITLE
Increase db-connection pool

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -11,7 +11,7 @@ data class DatabaseConfig(
     val jdbcUrl: String,
     val password: String,
     val username: String,
-    val poolSize: Int = 2,
+    val poolSize: Int = 4,
 )
 
 class Database(


### PR DESCRIPTION
Ser at tjenesten dropper med 5xx-feil innimellom etter at syfomoteadmin har begynt å bruke isnarmesteleder.

Forsøker å øke antall connections siden to connections kan være opptatt med å prosessere fra Kafka og cronjob'en som oppdaterer virksomhetsnavn.