### PR TITLE
Move variables in ApplicationEnvironment to separate clases

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -31,12 +31,12 @@ fun main() {
         }
 
         val wellKnownInternalAzureAD = getWellKnown(
-            wellKnownUrl = environment.azureAppWellKnownUrl
+            wellKnownUrl = environment.azure.appWellKnownUrl
         )
 
         module {
             databaseModule(
-                environment = environment,
+                databaseEnvironment = environment.database,
             )
             apiModule(
                 applicationState = applicationState,
@@ -57,7 +57,7 @@ fun main() {
         application.environment.log.info("Application is ready")
         launchKafkaTask(
             applicationState = applicationState,
-            applicationEnvironmentKafka = environment.kafka,
+            kafkaEnvironment = environment.kafka,
             database = applicationDatabase,
         )
         cronjobModule(

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -1,23 +1,35 @@
 package no.nav.syfo.application
 
 import io.ktor.server.application.*
+import no.nav.syfo.application.cache.RedisEnvironment
+import no.nav.syfo.application.database.DatabaseEnvironment
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.client.ClientEnvironment
+import no.nav.syfo.client.ClientsEnvironment
+import no.nav.syfo.client.azuread.AzureEnvironment
+
+const val NAIS_DATABASE_ENV_PREFIX = "NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER"
 
 data class Environment(
-    val azureAppClientId: String = getEnvVar("AZURE_APP_CLIENT_ID"),
-    val azureAppClientSecret: String = getEnvVar("AZURE_APP_CLIENT_SECRET"),
-    val azureAppPreAuthorizedApps: String = getEnvVar("AZURE_APP_PRE_AUTHORIZED_APPS"),
-    val azureAppWellKnownUrl: String = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
-    val azureOpenidConfigTokenEndpoint: String = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
+    val azure: AzureEnvironment = AzureEnvironment(
+        appClientId = getEnvVar("AZURE_APP_CLIENT_ID"),
+        appClientSecret = getEnvVar("AZURE_APP_CLIENT_SECRET"),
+        appPreAuthorizedApps = getEnvVar("AZURE_APP_PRE_AUTHORIZED_APPS"),
+        appWellKnownUrl = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
+        openidConfigTokenEndpoint = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
+    ),
+
+    val database: DatabaseEnvironment = DatabaseEnvironment(
+        host = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_HOST"),
+        name = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_DATABASE"),
+        port = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_PORT"),
+        password = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_PASSWORD"),
+        username = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_USERNAME"),
+    ),
 
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
 
-    val isnarmestelederDbHost: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_HOST"),
-    val isnarmestelederDbPort: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_PORT"),
-    val isnarmestelederDbName: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_DATABASE"),
-    val isnarmestelederDbUsername: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_USERNAME"),
-    val isnarmestelederDbPassword: String = getEnvVar("NAIS_DATABASE_ISNARMESTELEDER_ISNARMESTELEDER_DB_PASSWORD"),
-
-    val kafka: ApplicationEnvironmentKafka = ApplicationEnvironmentKafka(
+    val kafka: KafkaEnvironment = KafkaEnvironment(
         aivenBootstrapServers = getEnvVar("KAFKA_BROKERS"),
         aivenCredstorePassword = getEnvVar("KAFKA_CREDSTORE_PASSWORD"),
         aivenKeystoreLocation = getEnvVar("KAFKA_KEYSTORE_PATH"),
@@ -25,37 +37,33 @@ data class Environment(
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
     ),
 
-    val redisHost: String = getEnvVar("REDIS_HOST"),
-    val redisPort: Int = getEnvVar("REDIS_PORT", "6379").toInt(),
-    val redisSecret: String = getEnvVar("REDIS_PASSWORD"),
+    val redis: RedisEnvironment = RedisEnvironment(
+        host = getEnvVar("REDIS_HOST"),
+        port = getEnvVar("REDIS_PORT", "6379").toInt(),
+        secret = getEnvVar("REDIS_PASSWORD"),
+    ),
 
-    val isproxyClientId: String = getEnvVar("ISPROXY_CLIENT_ID"),
-    val isproxyUrl: String = getEnvVar("ISPROXY_URL"),
+    val clients: ClientsEnvironment = ClientsEnvironment(
+        isproxy = ClientEnvironment(
+            baseUrl = getEnvVar("ISPROXY_URL"),
+            clientId = getEnvVar("ISPROXY_CLIENT_ID"),
+        ),
+        pdl = ClientEnvironment(
+            baseUrl = getEnvVar("PDL_URL"),
+            clientId = getEnvVar("PDL_CLIENT_ID"),
+        ),
+        syfotilgangskontroll = ClientEnvironment(
+            baseUrl = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
+            clientId = getEnvVar("SYFOTILGANGSKONTROLL_CLIENT_ID"),
+        ),
+    ),
 
-    val pdlClientId: String = getEnvVar("PDL_CLIENT_ID"),
-    val pdlUrl: String = getEnvVar("PDL_URL"),
-
-    val syfotilgangskontrollClientId: String = getEnvVar("SYFOTILGANGSKONTROLL_CLIENT_ID"),
-    val syfotilgangskontrollUrl: String = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
-
-    val syfomoteadminApplicationName: String = "syfomoteadmin",
-    val isdialogmoteApplicationName: String = "isdialogmote",
+    private val syfomoteadminApplicationName: String = "syfomoteadmin",
+    private val isdialogmoteApplicationName: String = "isdialogmote",
     val systemAPIAuthorizedConsumerApplicationNameList: List<String> = listOf(
         syfomoteadminApplicationName,
         isdialogmoteApplicationName,
     ),
-) {
-    fun jdbcUrl(): String {
-        return "jdbc:postgresql://$isnarmestelederDbHost:$isnarmestelederDbPort/$isnarmestelederDbName"
-    }
-}
-
-data class ApplicationEnvironmentKafka(
-    val aivenBootstrapServers: String,
-    val aivenCredstorePassword: String,
-    val aivenKeystoreLocation: String,
-    val aivenSecurityProtocol: String,
-    val aivenTruststoreLocation: String,
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/application/cache/RedisEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cache/RedisEnvironment.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.application.cache
+
+data class RedisEnvironment(
+    val host: String,
+    val port: Int,
+    val secret: String,
+)

--- a/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
@@ -3,14 +3,22 @@ package no.nav.syfo.application.cache
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.syfo.util.configuredJacksonMapper
 import org.slf4j.LoggerFactory
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.*
 import redis.clients.jedis.exceptions.JedisConnectionException
 import kotlin.reflect.KClass
 
 class RedisStore(
-    private val jedisPool: JedisPool,
+    redisEnvironment: RedisEnvironment,
 ) {
     val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    private val jedisPool: JedisPool = JedisPool(
+        JedisPoolConfig(),
+        redisEnvironment.host,
+        redisEnvironment.port,
+        Protocol.DEFAULT_TIMEOUT,
+        redisEnvironment.secret,
+    )
 
     inline fun <reified T> getObject(
         key: String,

--- a/src/main/kotlin/no/nav/syfo/application/database/DatabaseEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/DatabaseEnvironment.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.application.database
+
+data class DatabaseEnvironment(
+    val host: String,
+    val name: String,
+    val port: String,
+    val password: String,
+    val username: String,
+) {
+    fun jdbcUrl(): String {
+        return "jdbc:postgresql://$host:$port/$name"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/application/database/DatabaseModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/DatabaseModule.kt
@@ -5,7 +5,7 @@ import no.nav.syfo.application.*
 
 lateinit var applicationDatabase: DatabaseInterface
 fun Application.databaseModule(
-    environment: Environment,
+    databaseEnvironment: DatabaseEnvironment,
 ) {
     isDev {
         applicationDatabase = Database(
@@ -20,9 +20,9 @@ fun Application.databaseModule(
     isProd {
         applicationDatabase = Database(
             DatabaseConfig(
-                jdbcUrl = environment.jdbcUrl(),
-                username = environment.isnarmestelederDbUsername,
-                password = environment.isnarmestelederDbPassword,
+                jdbcUrl = databaseEnvironment.jdbcUrl(),
+                username = databaseEnvironment.username,
+                password = databaseEnvironment.password,
             )
         )
     }

--- a/src/main/kotlin/no/nav/syfo/application/kafka/KafkaEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/kafka/KafkaEnvironment.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.application.kafka
+
+data class KafkaEnvironment(
+    val aivenBootstrapServers: String,
+    val aivenCredstorePassword: String,
+    val aivenKeystoreLocation: String,
+    val aivenSecurityProtocol: String,
+    val aivenTruststoreLocation: String,
+)

--- a/src/main/kotlin/no/nav/syfo/client/ClientEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ClientEnvironment.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.client
+
+data class ClientsEnvironment(
+    val isproxy: ClientEnvironment,
+    val pdl: ClientEnvironment,
+    val syfotilgangskontroll: ClientEnvironment,
+)
+
+data class ClientEnvironment(
+    val baseUrl: String,
+    val clientId: String,
+)

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
@@ -11,9 +11,7 @@ import no.nav.syfo.client.httpClientProxy
 import org.slf4j.LoggerFactory
 
 class AzureAdClient(
-    private val azureAppClientId: String,
-    private val azureAppClientSecret: String,
-    private val azureOpenidConfigTokenEndpoint: String,
+    private val azureEnviroment: AzureEnvironment,
     private val redisStore: RedisStore,
 ) {
     private val httpClient = httpClientProxy()
@@ -24,8 +22,8 @@ class AzureAdClient(
     ): AzureAdToken? {
         return getAccessToken(
             Parameters.build {
-                append("client_id", azureAppClientId)
-                append("client_secret", azureAppClientSecret)
+                append("client_id", azureEnviroment.appClientId)
+                append("client_secret", azureEnviroment.appClientSecret)
                 append("client_assertion_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
                 append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
                 append("assertion", token)
@@ -44,8 +42,8 @@ class AzureAdClient(
         } else {
             val azureAdTokenResponse = getAccessToken(
                 Parameters.build {
-                    append("client_id", azureAppClientId)
-                    append("client_secret", azureAppClientSecret)
+                    append("client_id", azureEnviroment.appClientId)
+                    append("client_secret", azureEnviroment.appClientSecret)
                     append("grant_type", "client_credentials")
                     append("scope", "api://$scopeClientId/.default")
                 }
@@ -67,7 +65,7 @@ class AzureAdClient(
         formParameters: Parameters,
     ): AzureAdTokenResponse? {
         return try {
-            val response: HttpResponse = httpClient.post(azureOpenidConfigTokenEndpoint) {
+            val response: HttpResponse = httpClient.post(azureEnviroment.openidConfigTokenEndpoint) {
                 accept(ContentType.Application.Json)
                 setBody(FormDataContent(formParameters))
             }

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureEnvironment.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.client.azuread
+
+data class AzureEnvironment(
+    val appClientId: String,
+    val appClientSecret: String,
+    val appPreAuthorizedApps: String,
+    val appWellKnownUrl: String,
+    val openidConfigTokenEndpoint: String,
+)

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.Virksomhetsnummer
@@ -15,13 +16,12 @@ import org.slf4j.LoggerFactory
 
 class EregClient(
     private val azureAdClient: AzureAdClient,
-    private val isproxyClientId: String,
-    baseUrl: String,
+    private val clientEnvironment: ClientEnvironment,
     private val redisStore: RedisStore,
 ) {
     private val httpClient = httpClientDefault()
 
-    private val eregOrganisasjonUrl: String = "$baseUrl/$EREG_PATH"
+    private val eregOrganisasjonUrl: String = "${clientEnvironment.baseUrl}/$EREG_PATH"
 
     suspend fun organisasjonVirksomhetsnavn(
         callId: String,
@@ -34,7 +34,7 @@ class EregClient(
             return cachedResponse
         } else {
             val systemToken = azureAdClient.getSystemToken(
-                scopeClientId = isproxyClientId,
+                scopeClientId = clientEnvironment.clientId,
             )?.accessToken
                 ?: throw RuntimeException("Failed to request Organisasjon from Isproxy-Ereg: Failed to get system token from AzureAD")
 

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.PersonIdentNumber
@@ -14,12 +15,11 @@ import org.slf4j.LoggerFactory
 
 class VeilederTilgangskontrollClient(
     private val azureAdClient: AzureAdClient,
-    private val syfotilgangskontrollClientId: String,
-    tilgangskontrollBaseUrl: String,
+    private val clientEnvironment: ClientEnvironment,
 ) {
     private val httpClient = httpClientDefault()
 
-    private val tilgangskontrollPersonUrl = "$tilgangskontrollBaseUrl$TILGANGSKONTROLL_PERSON_PATH"
+    private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
 
     suspend fun hasAccess(
         callId: String,
@@ -27,7 +27,7 @@ class VeilederTilgangskontrollClient(
         token: String,
     ): Boolean {
         val oboToken = azureAdClient.getOnBehalfOfToken(
-            scopeClientId = syfotilgangskontrollClientId,
+            scopeClientId = clientEnvironment.clientId,
             token = token
         )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -3,14 +3,13 @@ package no.nav.syfo.cronjob
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.cache.RedisStore
-import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
-import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnService
-import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnCronjob
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.ereg.EregClient
+import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
+import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnCronjob
+import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnService
 import no.nav.syfo.narmestelederrelasjon.kafka.launchBackgroundTask
-import redis.clients.jedis.*
 
 fun cronjobModule(
     applicationState: ApplicationState,
@@ -18,26 +17,17 @@ fun cronjobModule(
     environment: Environment,
 ) {
     val redisStore = RedisStore(
-        jedisPool = JedisPool(
-            JedisPoolConfig(),
-            environment.redisHost,
-            environment.redisPort,
-            Protocol.DEFAULT_TIMEOUT,
-            environment.redisSecret,
-        ),
+        redisEnvironment = environment.redis,
     )
 
     val azureAdClient = AzureAdClient(
-        azureAppClientId = environment.azureAppClientId,
-        azureAppClientSecret = environment.azureAppClientSecret,
-        azureOpenidConfigTokenEndpoint = environment.azureOpenidConfigTokenEndpoint,
+        azureEnviroment = environment.azure,
         redisStore = redisStore,
     )
 
     val eregClient = EregClient(
         azureAdClient = azureAdClient,
-        isproxyClientId = environment.isproxyClientId,
-        baseUrl = environment.isproxyUrl,
+        clientEnvironment = environment.clients.isproxy,
         redisStore = redisStore,
     )
 

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaConfig.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.narmestelederrelasjon.kafka
 
-import no.nav.syfo.application.ApplicationEnvironmentKafka
+import no.nav.syfo.application.kafka.KafkaEnvironment
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.SaslConfigs
@@ -9,10 +9,10 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import java.util.*
 
 fun kafkaNarmesteLederRelasjonConsumerConfig(
-    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+    kafkaEnvironment: KafkaEnvironment,
 ): Properties {
     return Properties().apply {
-        putAll(commonKafkaAivenConfig(applicationEnvironmentKafka))
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
 
         this[ConsumerConfig.GROUP_ID_CONFIG] = "isnarmesteleder-v2"
         this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
@@ -25,17 +25,17 @@ fun kafkaNarmesteLederRelasjonConsumerConfig(
 }
 
 private fun commonKafkaAivenConfig(
-    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+    kafkaEnvironment: KafkaEnvironment,
 ) = Properties().apply {
     this[SaslConfigs.SASL_MECHANISM] = "PLAIN"
-    this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = applicationEnvironmentKafka.aivenBootstrapServers
-    this[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = applicationEnvironmentKafka.aivenSecurityProtocol
+    this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = kafkaEnvironment.aivenBootstrapServers
+    this[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = kafkaEnvironment.aivenSecurityProtocol
     this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
     this[SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG] = "jks"
     this[SslConfigs.SSL_KEYSTORE_TYPE_CONFIG] = "PKCS12"
-    this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = applicationEnvironmentKafka.aivenTruststoreLocation
-    this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
-    this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = applicationEnvironmentKafka.aivenKeystoreLocation
-    this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
-    this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = applicationEnvironmentKafka.aivenCredstorePassword
+    this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenTruststoreLocation
+    this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenKeystoreLocation
+    this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
 }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaModule.kt
@@ -1,9 +1,9 @@
 package no.nav.syfo.narmestelederrelasjon.kafka
 
 import kotlinx.coroutines.*
-import no.nav.syfo.application.ApplicationEnvironmentKafka
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.kafka.KafkaEnvironment
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -25,13 +25,13 @@ fun launchBackgroundTask(
 
 fun launchKafkaTask(
     applicationState: ApplicationState,
-    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+    kafkaEnvironment: KafkaEnvironment,
     database: DatabaseInterface,
 ) {
     launchBackgroundTask(applicationState = applicationState) {
         blockingApplicationLogicNarmesteLederRelasjon(
             applicationState = applicationState,
-            applicationEnvironmentKafka = applicationEnvironmentKafka,
+            kafkaEnvironment = kafkaEnvironment,
             database = database,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaNarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/kafka/KafkaNarmesteLederRelasjon.kt
@@ -1,9 +1,9 @@
 package no.nav.syfo.narmestelederrelasjon.kafka
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.syfo.application.ApplicationEnvironmentKafka
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.narmestelederrelasjon.database.NoElementInsertedException
 import no.nav.syfo.narmestelederrelasjon.database.createNarmesteLederRelasjon
 import no.nav.syfo.narmestelederrelasjon.kafka.domain.NarmesteLederLeesah
@@ -20,12 +20,12 @@ const val NARMESTE_LEDER_RELASJON_TOPIC = "teamsykmelding.syfo-narmesteleder-lee
 
 fun blockingApplicationLogicNarmesteLederRelasjon(
     applicationState: ApplicationState,
-    applicationEnvironmentKafka: ApplicationEnvironmentKafka,
+    kafkaEnvironment: KafkaEnvironment,
     database: DatabaseInterface,
 ) {
     log.info("Setting up kafka consumer NarmesteLederLeesah")
 
-    val consumerProperties = kafkaNarmesteLederRelasjonConsumerConfig(applicationEnvironmentKafka)
+    val consumerProperties = kafkaNarmesteLederRelasjonConsumerConfig(kafkaEnvironment)
     val kafkaConsumerNarmesteLederRelasjon = KafkaConsumer<String, String>(consumerProperties)
 
     kafkaConsumerNarmesteLederRelasjon.subscribe(
@@ -77,7 +77,10 @@ fun createAndStoreNarmesteLederRelasjonFromRecords(
                     narmesteLederLeesah = narmesteLederLeesah,
                 )
             } catch (noElementInsertedException: NoElementInsertedException) {
-                log.warn("No NarmesteLederRelasjon was inserted into database, probably due to an attempt to insert a duplicate", noElementInsertedException)
+                log.warn(
+                    "No NarmesteLederRelasjon was inserted into database, probably due to an attempt to insert a duplicate",
+                    noElementInsertedException
+                )
                 COUNT_KAFKA_CONSUMER_NARMESTELEDERRELASJON_DUPLICATE.increment()
             }
         }

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiSpek.kt
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.common.TopicPartition
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import redis.clients.jedis.*
 import testhelper.*
 import testhelper.UserConstants.ARBEIDSTAKER_FNR
 import testhelper.UserConstants.ARBEIDSTAKER_NO_VIRKSOMHETNAVN
@@ -51,26 +50,17 @@ class NarmestelederSystemApiSpek : Spek({
         )
 
         val redisStore = RedisStore(
-            jedisPool = JedisPool(
-                JedisPoolConfig(),
-                externalMockEnvironment.environment.redisHost,
-                externalMockEnvironment.environment.redisPort,
-                Protocol.DEFAULT_TIMEOUT,
-                externalMockEnvironment.environment.redisSecret,
-            ),
+            redisEnvironment = externalMockEnvironment.environment.redis,
         )
 
         val azureAdClient = AzureAdClient(
-            azureAppClientId = externalMockEnvironment.environment.azureAppClientId,
-            azureAppClientSecret = externalMockEnvironment.environment.azureAppClientSecret,
-            azureOpenidConfigTokenEndpoint = externalMockEnvironment.environment.azureOpenidConfigTokenEndpoint,
+            azureEnviroment = externalMockEnvironment.environment.azure,
             redisStore = redisStore,
         )
 
         val eregClient = EregClient(
             azureAdClient = azureAdClient,
-            isproxyClientId = externalMockEnvironment.environment.isproxyClientId,
-            baseUrl = externalMockEnvironment.environment.isproxyUrl,
+            clientEnvironment = externalMockEnvironment.environment.clients.isproxy,
             redisStore = redisStore,
         )
 
@@ -98,7 +88,7 @@ class NarmestelederSystemApiSpek : Spek({
             describe("Get list of NarmestelederRelasjon for PersonIdent") {
                 val url = narmesteLederSystemApiV1Path
                 val validToken = generateJWT(
-                    externalMockEnvironment.environment.azureAppClientId,
+                    externalMockEnvironment.environment.azure.appClientId,
                     testSyfomoteadminClientId,
                     externalMockEnvironment.wellKnownInternalAzureAD.issuer,
                 )
@@ -259,7 +249,7 @@ class NarmestelederSystemApiSpek : Spek({
                     }
                     it("should return status Forbidden if unauthorized AZP is supplied") {
                         val validTokenUnauthorizedAZP = generateJWT(
-                            externalMockEnvironment.environment.azureAppClientId,
+                            externalMockEnvironment.environment.azure.appClientId,
                             "unauthorizedId",
                             externalMockEnvironment.wellKnownInternalAzureAD.issuer,
                         )

--- a/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
@@ -5,6 +5,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.azuread.*
 import no.nav.syfo.client.pdl.PdlClient.Companion.CACHE_PDL_PERSONIDENT_NAME_KEY_PREFIX
 import no.nav.syfo.client.pdl.PdlClient.Companion.CACHE_PDL_PERSONIDENT_NAME_TIME_TO_LIVE_SECONDS
@@ -35,8 +36,10 @@ class PdlClientSpek : Spek({
 
             val client = PdlClient(
                 azureAdClient = azureAdClientMock,
-                pdlBaseUrl = pdlMock.url,
-                pdlClientId = pdlClientId,
+                clientEnvironment = ClientEnvironment(
+                    baseUrl = pdlMock.url,
+                    clientId = pdlClientId,
+                ),
                 redisStore = redisStoreMock,
             )
 

--- a/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
@@ -30,8 +30,7 @@ class ExternalMockEnvironment {
         syfotilgangskontrollUrl = tilgangskontrollMock.url,
     )
     val redisServer = testRedis(
-        port = environment.redisPort,
-        secret = environment.redisSecret,
+        redisEnvironment = environment.redis,
     )
 
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -1,6 +1,13 @@
 package testhelper
 
-import no.nav.syfo.application.*
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.cache.RedisEnvironment
+import no.nav.syfo.application.database.DatabaseEnvironment
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.client.ClientEnvironment
+import no.nav.syfo.client.ClientsEnvironment
+import no.nav.syfo.client.azuread.AzureEnvironment
 import no.nav.syfo.narmestelederrelasjon.api.access.PreAuthorizedClient
 import no.nav.syfo.util.configuredJacksonMapper
 import java.net.ServerSocket
@@ -12,32 +19,47 @@ fun testEnvironment(
     pdlUrl: String = "pdl",
     syfotilgangskontrollUrl: String = "tilgangskontroll",
 ) = Environment(
-    azureAppClientId = "isnarmesteleder-client-id",
-    azureAppClientSecret = "isnarmesteleder-secret",
-    azureAppPreAuthorizedApps = configuredJacksonMapper().writeValueAsString(testAzureAppPreAuthorizedApps),
-    azureAppWellKnownUrl = "wellknown",
-    azureOpenidConfigTokenEndpoint = azureOpenIdTokenEndpoint,
+    azure = AzureEnvironment(
+        appClientId = "appClientId",
+        appClientSecret = "appClientSecret",
+        appPreAuthorizedApps = configuredJacksonMapper().writeValueAsString(testAzureAppPreAuthorizedApps),
+        appWellKnownUrl = "appWellKnownUrl",
+        openidConfigTokenEndpoint = azureOpenIdTokenEndpoint,
+    ),
+    database = DatabaseEnvironment(
+        host = "localhost",
+        port = "5432",
+        name = "isnarmesteleder_dev",
+        username = "username",
+        password = "password",
+    ),
     electorPath = "electorPath",
-    kafka = ApplicationEnvironmentKafka(
+    kafka = KafkaEnvironment(
         aivenBootstrapServers = kafkaBootstrapServers,
         aivenCredstorePassword = "credstorepassord",
         aivenKeystoreLocation = "keystore",
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = "truststore",
     ),
-    redisHost = "localhost",
-    redisSecret = "password",
-    isnarmestelederDbHost = "localhost",
-    isnarmestelederDbPort = "5432",
-    isnarmestelederDbName = "isnarmesteleder_dev",
-    isnarmestelederDbUsername = "username",
-    isnarmestelederDbPassword = "password",
-    isproxyClientId = "dev-fss.teamsykefravr.isproxy",
-    isproxyUrl = isproxyUrl,
-    pdlClientId = "dev-fss.pdl.pdl-api",
-    pdlUrl = pdlUrl,
-    syfotilgangskontrollClientId = "dev-fss.teamsykefravr.syfo-tilgangskontroll",
-    syfotilgangskontrollUrl = syfotilgangskontrollUrl,
+    clients = ClientsEnvironment(
+        isproxy = ClientEnvironment(
+            baseUrl = isproxyUrl,
+            clientId = "dev-fss.teamsykefravr.isproxy",
+        ),
+        pdl = ClientEnvironment(
+            baseUrl = pdlUrl,
+            clientId = "dev-fss.pdl.pdl-api",
+        ),
+        syfotilgangskontroll = ClientEnvironment(
+            baseUrl = syfotilgangskontrollUrl,
+            clientId = "dev-fss.teamsykefravr.syfotilgangskontroll",
+        ),
+    ),
+    redis = RedisEnvironment(
+        host = "localhost",
+        port = 6379,
+        secret = "password",
+    ),
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/testhelper/TestRedis.kt
+++ b/src/test/kotlin/testhelper/TestRedis.kt
@@ -1,11 +1,11 @@
 package testhelper
 
+import no.nav.syfo.application.cache.RedisEnvironment
 import redis.embedded.RedisServer
 
 fun testRedis(
-    port: Int,
-    secret: String,
+    redisEnvironment: RedisEnvironment,
 ): RedisServer = RedisServer.builder()
-    .port(port)
-    .setting("requirepass $secret")
+    .port(redisEnvironment.port)
+    .setting("requirepass ${redisEnvironment.secret}")
     .build()


### PR DESCRIPTION
Move variables in ApplicationEnvironment to separate environment classes for Azure, Kafka, Database, Redis and Clients to improve readability and resuability.