### PR TITLE
Selvbetjenings-api med tokenx

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -64,6 +64,8 @@ spec:
     application:
       enabled: true
       tenant: trygdeetaten.no
+  tokenx:
+    enabled: true
   envFrom:
     - secret: isnarmesteleder-redis-password
   gcp:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -64,6 +64,8 @@ spec:
     application:
       enabled: true
       tenant: nav.no
+  tokenx:
+    enabled: true
   envFrom:
     - secret: isnarmesteleder-redis-password
   gcp:

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -34,6 +34,10 @@ fun main() {
             wellKnownUrl = environment.azure.appWellKnownUrl
         )
 
+        val wellKnownSelvbetjening = getWellKnown(
+            wellKnownUrl = environment.tokenx.tokenxWellKnownUrl
+        )
+
         module {
             databaseModule(
                 databaseEnvironment = environment.database,
@@ -43,6 +47,7 @@ fun main() {
                 database = applicationDatabase,
                 environment = environment,
                 wellKnownInternalAzureAD = wellKnownInternalAzureAD,
+                wellKnownSelvbetjening = wellKnownSelvbetjening,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -19,6 +19,11 @@ data class Environment(
         openidConfigTokenEndpoint = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
     ),
 
+    val tokenx: TokenxEnvironment = TokenxEnvironment(
+        tokenxClientId = getEnvVar("TOKEN_X_CLIENT_ID"),
+        tokenxWellKnownUrl = getEnvVar("TOKEN_X_WELL_KNOWN_URL"),
+    ),
+
     val database: DatabaseEnvironment = DatabaseEnvironment(
         host = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_HOST"),
         name = getEnvVar("${NAIS_DATABASE_ENV_PREFIX}_DATABASE"),
@@ -64,6 +69,11 @@ data class Environment(
         syfomoteadminApplicationName,
         isdialogmoteApplicationName,
     ),
+)
+
+data class TokenxEnvironment(
+    val tokenxClientId: String,
+    val tokenxWellKnownUrl: String,
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -13,15 +13,15 @@ import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.WellKnown
 import no.nav.syfo.narmestelederrelasjon.NarmesteLederRelasjonService
+import no.nav.syfo.narmestelederrelasjon.api.*
 import no.nav.syfo.narmestelederrelasjon.api.access.APIConsumerAccessService
-import no.nav.syfo.narmestelederrelasjon.api.registrerNarmesteLederRelasjonApi
-import no.nav.syfo.narmestelederrelasjon.api.registrerNarmesteLederRelasjonSystemApi
 
 fun Application.apiModule(
     applicationState: ApplicationState,
     database: DatabaseInterface,
     environment: Environment,
     wellKnownInternalAzureAD: WellKnown,
+    wellKnownSelvbetjening: WellKnown,
 ) {
     installMetrics()
     installCallId()
@@ -32,6 +32,11 @@ fun Application.apiModule(
                 acceptedAudienceList = listOf(environment.azure.appClientId),
                 jwtIssuerType = JwtIssuerType.INTERNAL_AZUREAD,
                 wellKnown = wellKnownInternalAzureAD,
+            ),
+            JwtIssuer(
+                acceptedAudienceList = listOf(environment.tokenx.tokenxClientId),
+                jwtIssuerType = JwtIssuerType.SELVBETJENING,
+                wellKnown = wellKnownSelvbetjening,
             ),
         ),
     )
@@ -80,6 +85,11 @@ fun Application.apiModule(
             registrerNarmesteLederRelasjonSystemApi(
                 apiConsumerAccessService = apiConsumerAccessService,
                 authorizedApplicationNameList = environment.systemAPIAuthorizedConsumerApplicationNameList,
+                narmesteLederRelasjonService = narmesteLederRelasjonService,
+            )
+        }
+        authenticate(JwtIssuerType.SELVBETJENING.name) {
+            registrerNarmesteLederRelasjonSelvbetjeningApi(
                 narmesteLederRelasjonService = narmesteLederRelasjonService,
             )
         }

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/JwtIssuer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/JwtIssuer.kt
@@ -10,4 +10,5 @@ data class JwtIssuer(
 
 enum class JwtIssuerType {
     INTERNAL_AZUREAD,
+    SELVBETJENING,
 }

--- a/src/main/kotlin/no/nav/syfo/application/api/authentication/TokenAuth.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/authentication/TokenAuth.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.application.api.authentication
 
 import com.auth0.jwt.JWT
+import no.nav.syfo.domain.PersonIdentNumber
 
 const val JWT_CLAIM_NAVIDENT = "NAVident"
 const val JWT_CLAIM_AZP = "azp"
@@ -8,3 +9,8 @@ const val JWT_CLAIM_AZP = "azp"
 fun getConsumerClientId(token: String): String =
     JWT.decode(token).claims[JWT_CLAIM_AZP]?.asString()
         ?: throw IllegalArgumentException("Claim AZP was not found in token")
+
+fun getPersonIdentFromToken(token: String): PersonIdentNumber? {
+    val pid = JWT.decode(token).claims["pid"]
+    return pid?.asString()?.let { PersonIdentNumber(it) }
+}

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -60,7 +60,7 @@ class PdlClient(
         personIdentNumber: PersonIdentNumber,
     ): PdlHentIdenter? {
         val token = azureAdClient.getSystemToken(clientEnvironment.clientId)
-            ?: throw RuntimeException("Failed to send PdlHentIdenterRequest to PDL: No token was found")
+            ?: throw RuntimeException("Failed to get system token from AzureAD")
 
         val query = getPdlQuery(
             queryFilePath = "/pdl/hentIdenter.graphql",
@@ -139,7 +139,7 @@ class PdlClient(
         personIdentNumberList: List<PersonIdentNumber>,
     ): Map<String, String> {
         val token = azureAdClient.getSystemToken(clientEnvironment.clientId)
-            ?: throw RuntimeException("Failed to send request to PDL: No token was found")
+            ?: throw RuntimeException("Failed to get system token from AzureAD")
 
         val pdlPersonIdentNameMap = personList(
             callId = callId,

--- a/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederSelvbetjeningApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederrelasjon/api/NarmestelederSelvbetjeningApi.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.narmestelederrelasjon.api
+
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.application.api.authentication.getPersonIdentFromToken
+import no.nav.syfo.narmestelederrelasjon.NarmesteLederRelasjonService
+import no.nav.syfo.narmestelederrelasjon.domain.toNarmesteLederRelasjonDTO
+import no.nav.syfo.util.*
+
+const val narmesteLederSelvbetjeningApiV1Path = "/api/selvbetjening/v1/narmestelederrelasjoner"
+
+fun Route.registrerNarmesteLederRelasjonSelvbetjeningApi(
+    narmesteLederRelasjonService: NarmesteLederRelasjonService,
+) {
+    route(narmesteLederSelvbetjeningApiV1Path) {
+        get {
+            val callId = getCallId()
+            val token = getBearerHeader()
+                ?: throw IllegalArgumentException("No Authorization header supplied to selvbetjening api when getting narmestelederRelasjoner, callID=$callId")
+
+            val personIdent = getPersonIdentFromToken(token)
+                ?: throw IllegalArgumentException("No PersonIdent supplied to selvbetjening api when getting narmestelederRelasjoner, callID=$callId")
+
+            val narmesteLederRelasjonDTOList = narmesteLederRelasjonService.getNarmestelederRelasjonList(
+                callId = callId,
+                personIdentNumber = personIdent,
+            ).map {
+                it.toNarmesteLederRelasjonDTO()
+            }
+            call.respond(narmesteLederRelasjonDTOList)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
@@ -86,7 +86,7 @@ class NarmestelederApiSpek : Spek({
 
             describe("Get list of NarmestelederRelasjon for PersonIdent") {
                 val url = "$narmesteLederApiV1Path$narmesteLederApiV1PersonIdentPath"
-                val validToken = generateJWT(
+                val validToken = generateJWTAzureAD(
                     externalMockEnvironment.environment.azure.appClientId,
                     testSyfomoteadminClientId,
                     externalMockEnvironment.wellKnownInternalAzureAD.issuer,

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederTestUtil.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederTestUtil.kt
@@ -1,0 +1,78 @@
+package no.nav.syfo.application.narmesteleder.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import no.nav.syfo.narmestelederrelasjon.kafka.NARMESTE_LEDER_RELASJON_TOPIC
+import no.nav.syfo.narmestelederrelasjon.kafka.domain.NY_LEDER
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.common.TopicPartition
+import testhelper.UserConstants
+import testhelper.UserConstants.ARBEIDSTAKER_FNR
+import testhelper.generator.generateNarmesteLederLeesah
+import testhelper.mock.toHistoricalPersonIdentNumber
+import java.time.OffsetDateTime
+
+fun generateNarmestelederTestdata(): ConsumerRecords<String, String> {
+    val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    val partition = 0
+    val narmesteLederRelasjonTopicPartition = TopicPartition(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+        partition,
+    )
+    val narmesteLederLeesah = generateNarmesteLederLeesah(
+        arbeidstakerPersonIdentNumber = ARBEIDSTAKER_FNR.toHistoricalPersonIdentNumber(),
+        status = null,
+        timestamp = OffsetDateTime.now().minusDays(1),
+    )
+    val narmesteLederLeesahRecord = ConsumerRecord(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+        partition,
+        1,
+        "something",
+        objectMapper.writeValueAsString(narmesteLederLeesah),
+    )
+    val narmesteLederLeesahRecordDuplicate = ConsumerRecord(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+        partition,
+        1,
+        "something",
+        objectMapper.writeValueAsString(narmesteLederLeesah),
+    )
+    val ansattLeesah = generateNarmesteLederLeesah(
+        arbeidstakerPersonIdentNumber = UserConstants.NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE,
+        narmestelederPersonIdentNumber = ARBEIDSTAKER_FNR.toHistoricalPersonIdentNumber(),
+        status = null,
+        timestamp = OffsetDateTime.now().minusDays(1),
+    )
+    val ansattLeesahRecord = ConsumerRecord(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+        partition,
+        3,
+        "something",
+        objectMapper.writeValueAsString(ansattLeesah),
+    )
+    val narmesteLederLeesahNoVirksomhetsnavn = generateNarmesteLederLeesah(
+        arbeidstakerPersonIdentNumber = UserConstants.ARBEIDSTAKER_NO_VIRKSOMHETNAVN,
+        virksomhetsnummer = UserConstants.VIRKSOMHETSNUMMER_NO_VIRKSOMHETSNAVN,
+        status = NY_LEDER,
+    )
+    val narmesteLederLeesahRecordNoVirksomhetsnavn = ConsumerRecord(
+        NARMESTE_LEDER_RELASJON_TOPIC,
+        partition,
+        2,
+        "something",
+        objectMapper.writeValueAsString(narmesteLederLeesahNoVirksomhetsnavn),
+    )
+    return ConsumerRecords(
+        mapOf(
+            narmesteLederRelasjonTopicPartition to listOf(
+                narmesteLederLeesahRecord,
+                narmesteLederLeesahRecordDuplicate,
+                narmesteLederLeesahRecordNoVirksomhetsnavn,
+                ansattLeesahRecord,
+            )
+        )
+    )
+}

--- a/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
@@ -34,6 +34,7 @@ class ExternalMockEnvironment {
     )
 
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
+    val wellKnownSelvbetjening = wellKnownSelvbetjening()
 }
 
 fun ExternalMockEnvironment.startExternalMocks() {

--- a/src/test/kotlin/testhelper/JWTUtil.kt
+++ b/src/test/kotlin/testhelper/JWTUtil.kt
@@ -18,7 +18,7 @@ import java.util.*
 const val keyId = "localhost-signer"
 
 // Mock of JWT-token supplied by AzureAD. KeyId must match kid i jwkset.json
-fun generateJWT(
+fun generateJWTAzureAD(
     audience: String,
     azp: String,
     issuer: String,
@@ -47,7 +47,35 @@ fun generateJWT(
         .sign(alg)
 }
 
-private fun getDefaultRSAKey(): RSAKey {
+fun generateJWTTokenx(
+    audience: String,
+    clientId: String,
+    issuer: String,
+    subject: String? = null,
+    expiry: LocalDateTime? = LocalDateTime.now().plusHours(1)
+): String {
+    val now = Date()
+    val key = getDefaultRSAKey()
+    val alg = Algorithm.RSA256(key.toRSAPublicKey(), key.toRSAPrivateKey())
+
+    return JWT.create()
+        .withKeyId(keyId)
+        .withSubject(subject ?: "subject")
+        .withIssuer(issuer)
+        .withAudience(audience)
+        .withJWTId(UUID.randomUUID().toString())
+        .withClaim("ver", "1.0")
+        .withClaim("nonce", "myNonce")
+        .withClaim("auth_time", now)
+        .withClaim("nbf", now)
+        .withClaim("iat", now)
+        .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
+        .withClaim("client_id", clientId)
+        .withClaim("pid", subject ?: "pid")
+        .sign(alg)
+}
+
+fun getDefaultRSAKey(): RSAKey {
     return getJWKSet().getKeyByKeyId(keyId) as RSAKey
 }
 

--- a/src/test/kotlin/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/testhelper/TestApiModule.kt
@@ -11,5 +11,6 @@ fun Application.testApiModule(
         database = externalMockEnvironment.database,
         environment = externalMockEnvironment.environment,
         wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
+        wellKnownSelvbetjening = externalMockEnvironment.wellKnownSelvbetjening,
     )
 }

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -1,7 +1,6 @@
 package testhelper
 
-import no.nav.syfo.application.ApplicationState
-import no.nav.syfo.application.Environment
+import no.nav.syfo.application.*
 import no.nav.syfo.application.cache.RedisEnvironment
 import no.nav.syfo.application.database.DatabaseEnvironment
 import no.nav.syfo.application.kafka.KafkaEnvironment
@@ -25,6 +24,10 @@ fun testEnvironment(
         appPreAuthorizedApps = configuredJacksonMapper().writeValueAsString(testAzureAppPreAuthorizedApps),
         appWellKnownUrl = "appWellKnownUrl",
         openidConfigTokenEndpoint = azureOpenIdTokenEndpoint,
+    ),
+    tokenx = TokenxEnvironment(
+        tokenxClientId = "tokenxClientId",
+        tokenxWellKnownUrl = "tokenxWellKnownUrl",
     ),
     database = DatabaseEnvironment(
         host = "localhost",
@@ -72,6 +75,7 @@ fun getRandomPort() = ServerSocket(0).use {
 }
 
 const val testSyfomoteadminClientId = "syfomoteadmin-client-id"
+
 val testAzureAppPreAuthorizedApps = listOf(
     PreAuthorizedClient(
         name = "dev-fss:teamsykefravr:syfomoteadmin",

--- a/src/test/kotlin/testhelper/UserConstants.kt
+++ b/src/test/kotlin/testhelper/UserConstants.kt
@@ -2,6 +2,7 @@ package testhelper
 
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.domain.Virksomhetsnummer
+import java.time.LocalDate
 
 object UserConstants {
     val ARBEIDSTAKER_FNR = PersonIdentNumber("12345678912")
@@ -10,6 +11,9 @@ object UserConstants {
 
     val NARMESTELEDER_PERSONIDENTNUMBER = PersonIdentNumber("01015432101")
     val NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE = PersonIdentNumber("20025432101")
+    val NARMESTELEDER_TELEFON = "99119911"
+    val NARMESTELEDER_EPOST = "test@test.com"
+    val NARMESTELEDER_AKTIV_FOM = LocalDate.now().minusDays(10)
 
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer("912345678")
     val VIRKSOMHETSNUMMER_ALTERNATIVE = Virksomhetsnummer(VIRKSOMHETSNUMMER_DEFAULT.value.replace("1", "2"))

--- a/src/test/kotlin/testhelper/generator/NarmesteLederLeesahGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/NarmesteLederLeesahGenerator.kt
@@ -6,8 +6,10 @@ import no.nav.syfo.narmestelederrelasjon.kafka.domain.NY_LEDER
 import no.nav.syfo.narmestelederrelasjon.kafka.domain.NarmesteLederLeesah
 import testhelper.UserConstants
 import testhelper.UserConstants.ARBEIDSTAKER_FNR
+import testhelper.UserConstants.NARMESTELEDER_AKTIV_FOM
+import testhelper.UserConstants.NARMESTELEDER_EPOST
 import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER
-import java.time.LocalDate
+import testhelper.UserConstants.NARMESTELEDER_TELEFON
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -22,9 +24,9 @@ fun generateNarmesteLederLeesah(
     fnr = arbeidstakerPersonIdentNumber.value,
     orgnummer = virksomhetsnummer.value,
     narmesteLederFnr = narmestelederPersonIdentNumber.value,
-    narmesteLederTelefonnummer = "99119911",
-    narmesteLederEpost = "test@test.com",
-    aktivFom = LocalDate.now().minusDays(10),
+    narmesteLederTelefonnummer = NARMESTELEDER_TELEFON,
+    narmesteLederEpost = NARMESTELEDER_EPOST,
+    aktivFom = NARMESTELEDER_AKTIV_FOM,
     aktivTom = null,
     arbeidsgiverForskutterer = null,
     timestamp = timestamp,

--- a/src/test/kotlin/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/testhelper/mock/AzureADMock.kt
@@ -16,7 +16,16 @@ fun wellKnownInternalAzureAD(): WellKnown {
     val uri = Paths.get(path).toUri().toURL()
     return WellKnown(
         issuer = "https://sts.issuer.net/veileder/v2",
-        jwksUri = uri.toString()
+        jwksUri = uri.toString(),
+    )
+}
+
+fun wellKnownSelvbetjening(): WellKnown {
+    val path = "src/test/resources/jwkset.json"
+    val uri = Paths.get(path).toUri().toURL()
+    return WellKnown(
+        issuer = "https://tokendings.dev-gcp.nais.io",
+        jwksUri = uri.toString(),
     )
 }
 


### PR DESCRIPTION
Dette skal brukes fra isdialogmote.

Det er mulig å bruke tokenx mot PDL også, men det funker ikke for isnarmesteleder siden PDL begrenser tilgangen til å bare gjelde tilgang til personidenten som er gitt av token'et. Det er ikke nok for oppslaget fra isnarmesteleder siden poenget der er å hente data for arbeidstakerne for den aktuelle nærmesteleder-personen. Så må fortsatt bruke system-token for det PDL-oppslaget.