### PR TITLE
Forenklet mock-oppsett i tester

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
 
     testImplementation("com.nimbusds:nimbus-jose-jwt:$nimbusJoseJwt")
     testImplementation("io.ktor:ktor-server-test-host:$ktor")
+    testImplementation("io.ktor:ktor-client-mock:$ktor")
     testImplementation("io.mockk:mockk:$mockk")
     testImplementation("org.amshove.kluent:kluent:$kluent")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spek") {

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -6,10 +6,7 @@ import io.ktor.server.routing.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.api.authentication.*
-import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.database.DatabaseInterface
-import no.nav.syfo.client.azuread.AzureAdClient
-import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.WellKnown
 import no.nav.syfo.narmestelederrelasjon.NarmesteLederRelasjonService
@@ -22,7 +19,8 @@ fun Application.apiModule(
     environment: Environment,
     wellKnownInternalAzureAD: WellKnown,
     wellKnownSelvbetjening: WellKnown,
-    redisStore: RedisStore,
+    veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    narmesteLederRelasjonService: NarmesteLederRelasjonService,
 ) {
     installMetrics()
     installCallId()
@@ -42,27 +40,6 @@ fun Application.apiModule(
         ),
     )
     installStatusPages()
-
-    val azureAdClient = AzureAdClient(
-        azureEnviroment = environment.azure,
-        redisStore = redisStore,
-    )
-
-    val pdlClient = PdlClient(
-        azureAdClient = azureAdClient,
-        clientEnvironment = environment.clients.pdl,
-        redisStore = redisStore,
-    )
-
-    val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
-        azureAdClient = azureAdClient,
-        clientEnvironment = environment.clients.tilgangskontroll,
-    )
-
-    val narmesteLederRelasjonService = NarmesteLederRelasjonService(
-        database = database,
-        pdlClient = pdlClient,
-    )
 
     val apiConsumerAccessService = APIConsumerAccessService(
         azureAppPreAuthorizedApps = environment.azure.appPreAuthorizedApps,

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.azuread
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -13,8 +14,8 @@ import org.slf4j.LoggerFactory
 class AzureAdClient(
     private val azureEnviroment: AzureEnvironment,
     private val redisStore: RedisStore,
+    private val httpClient: HttpClient = httpClientProxy(),
 ) {
-    private val httpClient = httpClientProxy()
 
     suspend fun getOnBehalfOfToken(
         scopeClientId: String,

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.ereg
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -15,8 +16,8 @@ import org.slf4j.LoggerFactory
 class EregClient(
     clientEnvironment: ClientEnvironment,
     private val redisStore: RedisStore,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     private val eregOrganisasjonUrl: String = "${clientEnvironment.baseUrl}/$EREG_PATH"
 

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.pdl
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -18,8 +19,8 @@ class PdlClient(
     private val azureAdClient: AzureAdClient,
     private val clientEnvironment: ClientEnvironment,
     private val redisStore: RedisStore,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     suspend fun identList(
         callId: String,

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.veiledertilgang
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -16,8 +17,8 @@ import org.slf4j.LoggerFactory
 class VeilederTilgangskontrollClient(
     private val azureAdClient: AzureAdClient,
     private val clientEnvironment: ClientEnvironment,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
 

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederApiSpek.kt
@@ -29,6 +29,8 @@ import testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import testhelper.UserConstants.VEILEDER_IDENT
 import testhelper.UserConstants.VIRKSOMHETSNUMMER_NO_VIRKSOMHETSNAVN
 import testhelper.generator.generateNarmesteLederLeesah
+import testhelper.mock.eregOrganisasjonMockResponse
+import testhelper.mock.pdlPersonMockRespons
 import testhelper.mock.toHistoricalPersonIdentNumber
 import java.time.Duration
 import java.time.OffsetDateTime
@@ -49,6 +51,7 @@ class NarmestelederApiSpek : Spek({
         val eregClient = EregClient(
             clientEnvironment = externalMockEnvironment.environment.clients.ereg,
             redisStore = externalMockEnvironment.redisCache,
+            httpClient = externalMockEnvironment.mockHttpClient,
         )
 
         val virksomhetsnavnCronjob = VirksomhetsnavnCronjob(
@@ -60,14 +63,6 @@ class NarmestelederApiSpek : Spek({
 
         afterEachTest {
             database.dropData()
-        }
-
-        beforeGroup {
-            externalMockEnvironment.startExternalMocks()
-        }
-
-        afterGroup {
-            externalMockEnvironment.stopExternalMocks()
         }
 
         describe(NarmestelederApiSpek::class.java.simpleName) {
@@ -168,12 +163,12 @@ class NarmestelederApiSpek : Spek({
 
                             val narmesteLederRelasjonDeaktivert = narmestelederRelasjonList.first()
                             narmesteLederRelasjonDeaktivert.arbeidstakerPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
-                            narmesteLederRelasjonDeaktivert.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.eregMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
+                            narmesteLederRelasjonDeaktivert.virksomhetsnavn shouldBeEqualTo eregOrganisasjonMockResponse.toEregVirksomhetsnavn().virksomhetsnavn
                             narmesteLederRelasjonDeaktivert.virksomhetsnummer shouldBeEqualTo narmesteLederLeesah.orgnummer
                             narmesteLederRelasjonDeaktivert.narmesteLederPersonIdentNumber shouldBeEqualTo narmesteLederLeesah.narmesteLederFnr
                             narmesteLederRelasjonDeaktivert.narmesteLederTelefonnummer shouldBeEqualTo narmesteLederLeesah.narmesteLederTelefonnummer
                             narmesteLederRelasjonDeaktivert.narmesteLederEpost shouldBeEqualTo narmesteLederLeesah.narmesteLederEpost
-                            narmesteLederRelasjonDeaktivert.narmesteLederNavn shouldBeEqualTo externalMockEnvironment.pdlMock.respons.data.hentPersonBolk?.get(
+                            narmesteLederRelasjonDeaktivert.narmesteLederNavn shouldBeEqualTo pdlPersonMockRespons.data.hentPersonBolk?.get(
                                 0
                             )?.person?.fullName()
                             narmesteLederRelasjonDeaktivert.aktivFom shouldBeEqualTo narmesteLederLeesah.aktivFom

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSelvbetjeningApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSelvbetjeningApiSpek.kt
@@ -24,6 +24,8 @@ import testhelper.*
 import testhelper.UserConstants.ARBEIDSTAKER_FNR
 import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE
 import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
+import testhelper.mock.eregOrganisasjonMockResponse
+import testhelper.mock.pdlPersonMockRespons
 import java.time.Duration
 
 class NarmestelederSelvbetjeningApiSpek : Spek({
@@ -42,6 +44,7 @@ class NarmestelederSelvbetjeningApiSpek : Spek({
         val eregClient = EregClient(
             clientEnvironment = externalMockEnvironment.environment.clients.ereg,
             redisStore = externalMockEnvironment.redisCache,
+            httpClient = externalMockEnvironment.mockHttpClient,
         )
 
         val virksomhetsnavnCronjob = VirksomhetsnavnCronjob(
@@ -53,14 +56,6 @@ class NarmestelederSelvbetjeningApiSpek : Spek({
 
         afterEachTest {
             database.dropData()
-        }
-
-        beforeGroup {
-            externalMockEnvironment.startExternalMocks()
-        }
-
-        afterGroup {
-            externalMockEnvironment.stopExternalMocks()
         }
 
         describe(NarmestelederSelvbetjeningApiSpek::class.java.simpleName) {
@@ -127,12 +122,12 @@ class NarmestelederSelvbetjeningApiSpek : Spek({
                             ansattRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
 
                             lederRelasjon.arbeidstakerPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
-                            lederRelasjon.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.eregMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
+                            lederRelasjon.virksomhetsnavn shouldBeEqualTo eregOrganisasjonMockResponse.toEregVirksomhetsnavn().virksomhetsnavn
                             lederRelasjon.virksomhetsnummer shouldBeEqualTo VIRKSOMHETSNUMMER_DEFAULT.value
                             lederRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo UserConstants.NARMESTELEDER_PERSONIDENTNUMBER.value
                             lederRelasjon.narmesteLederTelefonnummer shouldBeEqualTo UserConstants.NARMESTELEDER_TELEFON
                             lederRelasjon.narmesteLederEpost shouldBeEqualTo UserConstants.NARMESTELEDER_EPOST
-                            lederRelasjon.narmesteLederNavn shouldBeEqualTo externalMockEnvironment.pdlMock.respons.data.hentPersonBolk?.get(
+                            lederRelasjon.narmesteLederNavn shouldBeEqualTo pdlPersonMockRespons.data.hentPersonBolk?.get(
                                 0
                             )?.person?.fullName()
                             lederRelasjon.aktivFom shouldBeEqualTo UserConstants.NARMESTELEDER_AKTIV_FOM

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiLederBytteSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiLederBytteSpek.kt
@@ -7,9 +7,6 @@ import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import no.nav.syfo.client.ereg.EregClient
-import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnCronjob
-import no.nav.syfo.cronjob.virksomhetsnavn.VirksomhetsnavnService
 import no.nav.syfo.narmestelederrelasjon.api.NarmesteLederRelasjonDTO
 import no.nav.syfo.narmestelederrelasjon.api.narmesteLederSystemApiV1Path
 import no.nav.syfo.narmestelederrelasjon.domain.NarmesteLederRelasjonStatus
@@ -37,28 +34,8 @@ class NarmestelederSystemApiLederBytteSpek : Spek({
             externalMockEnvironment = externalMockEnvironment,
         )
 
-        val eregClient = EregClient(
-            clientEnvironment = externalMockEnvironment.environment.clients.ereg,
-            redisStore = externalMockEnvironment.redisCache,
-        )
-
-        val virksomhetsnavnCronjob = VirksomhetsnavnCronjob(
-            eregClient = eregClient,
-            virksomhetsnavnService = VirksomhetsnavnService(
-                database = database,
-            ),
-        )
-
         afterEachTest {
             database.dropData()
-        }
-
-        beforeGroup {
-            externalMockEnvironment.startExternalMocks()
-        }
-
-        afterGroup {
-            externalMockEnvironment.stopExternalMocks()
         }
 
         describe(NarmestelederSystemApiLederBytteSpek::class.java.simpleName) {

--- a/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/narmesteleder/api/NarmestelederSystemApiSpek.kt
@@ -27,6 +27,8 @@ import testhelper.UserConstants.NARMESTELEDER_AKTIV_FOM
 import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER
 import testhelper.UserConstants.NARMESTELEDER_PERSONIDENTNUMBER_ALTERNATIVE
 import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
+import testhelper.mock.eregOrganisasjonMockResponse
+import testhelper.mock.pdlPersonMockRespons
 import java.time.Duration
 
 class NarmestelederSystemApiSpek : Spek({
@@ -45,6 +47,7 @@ class NarmestelederSystemApiSpek : Spek({
         val eregClient = EregClient(
             clientEnvironment = externalMockEnvironment.environment.clients.ereg,
             redisStore = externalMockEnvironment.redisCache,
+            httpClient = externalMockEnvironment.mockHttpClient,
         )
 
         val virksomhetsnavnCronjob = VirksomhetsnavnCronjob(
@@ -56,14 +59,6 @@ class NarmestelederSystemApiSpek : Spek({
 
         afterEachTest {
             database.dropData()
-        }
-
-        beforeGroup {
-            externalMockEnvironment.startExternalMocks()
-        }
-
-        afterGroup {
-            externalMockEnvironment.stopExternalMocks()
         }
 
         describe(NarmestelederSystemApiSpek::class.java.simpleName) {
@@ -129,12 +124,12 @@ class NarmestelederSystemApiSpek : Spek({
                             ansattRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
 
                             lederRelasjon.arbeidstakerPersonIdentNumber shouldBeEqualTo ARBEIDSTAKER_FNR.value
-                            lederRelasjon.virksomhetsnavn shouldBeEqualTo externalMockEnvironment.eregMock.eregOrganisasjonResponse.toEregVirksomhetsnavn().virksomhetsnavn
+                            lederRelasjon.virksomhetsnavn shouldBeEqualTo eregOrganisasjonMockResponse.toEregVirksomhetsnavn().virksomhetsnavn
                             lederRelasjon.virksomhetsnummer shouldBeEqualTo VIRKSOMHETSNUMMER_DEFAULT.value
                             lederRelasjon.narmesteLederPersonIdentNumber shouldBeEqualTo NARMESTELEDER_PERSONIDENTNUMBER.value
                             lederRelasjon.narmesteLederTelefonnummer shouldBeEqualTo UserConstants.NARMESTELEDER_TELEFON
                             lederRelasjon.narmesteLederEpost shouldBeEqualTo UserConstants.NARMESTELEDER_EPOST
-                            lederRelasjon.narmesteLederNavn shouldBeEqualTo externalMockEnvironment.pdlMock.respons.data.hentPersonBolk?.get(
+                            lederRelasjon.narmesteLederNavn shouldBeEqualTo pdlPersonMockRespons.data.hentPersonBolk?.get(
                                 0
                             )?.person?.fullName()
                             lederRelasjon.aktivFom shouldBeEqualTo NARMESTELEDER_AKTIV_FOM

--- a/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
@@ -1,6 +1,5 @@
 package testhelper
 
-import io.ktor.server.netty.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.cache.RedisStore
 import testhelper.mock.*
@@ -9,53 +8,16 @@ class ExternalMockEnvironment {
     val applicationState: ApplicationState = testAppState()
     val database = TestDatabase()
 
-    val azureAdMock = AzureAdMock()
-    val eregMock = EregMock()
-    val pdlMock = PdlMock()
-    val tilgangskontrollMock = VeilederTilgangskontrollMock()
+    val environment = testEnvironment()
+    val mockHttpClient = mockHttpClient(environment = environment)
 
-    val externalApplicationMockMap = hashMapOf(
-        azureAdMock.name to azureAdMock.server,
-        eregMock.name to eregMock.server,
-        pdlMock.name to pdlMock.server,
-        tilgangskontrollMock.name to tilgangskontrollMock.server,
-    )
-
-    val environment = testEnvironment(
-        azureOpenIdTokenEndpoint = azureAdMock.url,
-        eregUrl = eregMock.url,
-        pdlUrl = pdlMock.url,
-        tilgangskontrollUrl = tilgangskontrollMock.url,
-    )
     lateinit var redisCache: RedisStore
     val redisServer = testRedis(environment.redisConfig)
 
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
     val wellKnownSelvbetjening = wellKnownSelvbetjening()
-}
 
-fun ExternalMockEnvironment.startExternalMocks() {
-    this.externalApplicationMockMap.start()
-    this.redisServer.start()
-}
-
-fun ExternalMockEnvironment.stopExternalMocks() {
-    this.externalApplicationMockMap.stop()
-    this.database.stop()
-    this.redisServer.stop()
-}
-
-fun HashMap<String, NettyApplicationEngine>.start() {
-    this.forEach {
-        it.value.start()
-    }
-}
-
-fun HashMap<String, NettyApplicationEngine>.stop(
-    gracePeriodMillis: Long = 1L,
-    timeoutMillis: Long = 10L,
-) {
-    this.forEach {
-        it.value.stop(gracePeriodMillis, timeoutMillis)
+    companion object {
+        val instance: ExternalMockEnvironment = ExternalMockEnvironment().also { it.redisServer.start() }
     }
 }

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.client.ClientsEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
 import no.nav.syfo.narmestelederrelasjon.api.access.PreAuthorizedClient
 import no.nav.syfo.util.configuredJacksonMapper
-import java.net.ServerSocket
 import java.net.URI
 
 fun testEnvironment(
@@ -71,10 +70,6 @@ fun testAppState() = ApplicationState(
     alive = true,
     ready = true,
 )
-
-fun getRandomPort() = ServerSocket(0).use {
-    it.localPort
-}
 
 const val testIsdialogmoteClientId = "isdialogmote-client-id"
 const val testSyfomodiapersonClientId = "syfomodiaperson-client-id"

--- a/src/test/kotlin/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/testhelper/mock/AzureADMock.kt
@@ -1,14 +1,9 @@
 package testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import no.nav.syfo.application.api.installContentNegotiation
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import no.nav.syfo.client.azuread.AzureAdTokenResponse
 import no.nav.syfo.client.wellknown.WellKnown
-import testhelper.getRandomPort
 import java.nio.file.Paths
 
 fun wellKnownInternalAzureAD(): WellKnown {
@@ -29,26 +24,10 @@ fun wellKnownSelvbetjening(): WellKnown {
     )
 }
 
-class AzureAdMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    private val azureAdTokenResponse = AzureAdTokenResponse(
+fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respondOk(
+    AzureAdTokenResponse(
         access_token = "token",
         expires_in = 3600,
         token_type = "type",
     )
-
-    val name = "azuread"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            post {
-                call.respond(azureAdTokenResponse)
-            }
-        }
-    }
-}
+)

--- a/src/test/kotlin/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/testhelper/mock/MockHttpClient.kt
@@ -1,0 +1,23 @@
+package testhelper.mock
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import no.nav.syfo.application.Environment
+import no.nav.syfo.client.commonConfig
+
+fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
+    commonConfig()
+    engine {
+        addHandler { request ->
+            val requestUrl = request.url.encodedPath
+            when {
+                requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" -> azureAdMockResponse()
+                requestUrl.startsWith("/${environment.clients.tilgangskontroll.baseUrl}") -> tilgangskontrollResponse(request)
+                requestUrl.startsWith("/${environment.clients.pdl.baseUrl}") -> pdlMockResponse(request)
+                requestUrl.startsWith("/${environment.clients.ereg.baseUrl}") -> eregMockResponse(request)
+
+                else -> error("Unhandled ${request.url.encodedPath}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/testhelper/mock/MockUtils.kt
+++ b/src/test/kotlin/testhelper/mock/MockUtils.kt
@@ -1,0 +1,19 @@
+package testhelper.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.util.configuredJacksonMapper
+
+val mapper = configuredJacksonMapper()
+
+fun <T> MockRequestHandleScope.respondOk(body: T): HttpResponseData =
+    respond(
+        mapper.writeValueAsString(body),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+suspend inline fun <reified T> HttpRequestData.receiveBody(): T {
+    return mapper.readValue(body.toByteArray(), T::class.java)
+}

--- a/src/test/kotlin/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -1,48 +1,18 @@
 package testhelper.mock
 
-import io.ktor.server.application.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import no.nav.syfo.application.api.installContentNegotiation
 import no.nav.syfo.client.veiledertilgang.Tilgang
-import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_PATH
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
-import testhelper.getRandomPort
 
-class VeilederTilgangskontrollMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-    val tilgangFalse = Tilgang(
-        erGodkjent = false,
-    )
-    val tilgangTrue = Tilgang(
-        erGodkjent = true,
-    )
+fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
+    val personident = request.headers[NAV_PERSONIDENT_HEADER]
 
-    val name = "veiledertilgangskontroll"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(TILGANGSKONTROLL_PERSON_PATH) {
-                when {
-                    call.request.headers[NAV_PERSONIDENT_HEADER] == ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> {
-                        call.respond(HttpStatusCode.Forbidden, tilgangFalse)
-                    }
-                    call.request.headers[NAV_PERSONIDENT_HEADER] != null -> {
-                        call.respond(tilgangTrue)
-                    }
-                    else -> {
-                        call.respond(HttpStatusCode.BadRequest)
-                    }
-                }
-            }
-        }
+    return when {
+        personident == ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> respondOk(body = Tilgang(erGodkjent = false))
+        personident != null -> respondOk(Tilgang(erGodkjent = true))
+        else -> respondError(HttpStatusCode.BadRequest)
     }
 }


### PR DESCRIPTION
Bruker MockEngine som vi gjør i de fleste andre appene vår (https://ktor.io/docs/client-testing.html) i stedet for å starte en NettyServer per mock.